### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Humblemonk/shurectl/security/code-scanning/1](https://github.com/Humblemonk/shurectl/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the root or per job) that specifies the least privileges the job needs. For a simple Rust build-and-test workflow that only reads source code, `contents: read` is sufficient and matches CodeQL’s suggested minimal starting point.

The best fix here, without changing existing functionality, is to add a top-level `permissions` section right under the workflow name. This applies to all jobs unless they override it, and it clearly documents that the `GITHUB_TOKEN` may only read repository contents. No additional methods, imports, or other definitions are required; it is purely a YAML configuration change inside `.github/workflows/rust.yml`.

Concretely, in `.github/workflows/rust.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: Rust` line (line 1). All other lines and behavior remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
