### PR TITLE
Update GitHub Actions to not persist credentials

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Set persist-credentials to false for checkout action.