### PR TITLE
V1.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ src/
   app.rs        # Application state: Tab, Focus, DeviceState, DeviceAction events
   device.rs     # hidapi wrapper: open MVX2U, send/receive HID reports
   meter.rs      # cpal audio capture: real-time dBFS metering, RollingWindow, PeakWindow
+  presets.rs    # Host-side preset storage: TOML serialisation, load/save/delete, PresetSlot
   protocol.rs   # Packet encoding, CRC-16/ANSI, all command constructors, apply_response()
   ui.rs         # ratatui rendering: all 5 tabs + help overlay
 ```
@@ -152,6 +153,34 @@ into `App`, shared via `Arc`:
 `start_meter()` returns a `MeterStatus` enum. The caller must keep the `Stream` inside
 `MeterStatus::Running` alive — dropping it stops capture. The meter is not started in demo mode.
 
+### Preset Storage
+
+`presets.rs` implements host-side preset management. Presets are stored as TOML files in
+`~/.config/shurectl/presets/`, with 4 fixed slots named `preset_1.toml`–`preset_4.toml`.
+
+Key design decisions:
+- **Mirror types**: `presets.rs` defines separate `Ser*` enums (`SerInputMode`, `SerMicPosition`,
+  etc.) with `#[derive(Serialize, Deserialize)]`. Protocol types in `protocol.rs` stay free of
+  serde concerns. Stable on-disk format is decoupled from internal enum evolution.
+- **`PresetSlot`**: captures all configurable DSP settings from `DeviceState` — every field
+  that can be sent to the MVX2U over HID. Hardware-identity fields (`serial_number`,
+  `firmware_version`) are intentionally excluded.
+- **`PresetSlot::from_device_state()`** — snapshot live state into a slot.
+- **`PresetSlot::apply_to_device_state()`** — restore a slot onto `DeviceState`, preserving identity fields.
+- **`load_all_presets()`** — loads all 4 slots at startup; missing files produce `None` entries.
+- **`dirs_next::config_dir()`** — resolves `~/.config/` on Linux; falls back to `$HOME/.config/`
+  if `dirs-next` returns `None`.
+
+`DeviceAction` preset variants (handled in `main.rs::apply_action()`):
+- `SavePreset(usize)` — snapshot current state, write TOML, update `app.presets[i]`
+- `LoadPreset(usize)` — call `apply_to_device_state()`, send all SET commands to device
+- `DeletePreset(usize)` — remove the TOML file, set `app.presets[i] = None`
+- `PersistPresetName(usize)` — write the already-in-memory-updated name back to disk
+
+Preset name editing is handled in `main.rs::handle_key()`, not in `toggle_focused()`.
+When `app.editing_preset_name` is `true`, character keys append to the name and `Enter`
+commits (fires `PersistPresetName`), while `Esc` cancels without saving.
+
 ### Demo Mode
 
 `--demo` runs with `device: None`. `send_if_connected()` silently succeeds when
@@ -160,13 +189,17 @@ This is intentional: demo mode should always be fully navigable.
 
 ### Key Crates in Use
 
-- `ratatui 0.26` — TUI rendering; use `Frame::render_widget()`, not direct buffer writes
-- `crossterm 0.27` — terminal backend and key events; `KeyEventKind::Press` only
+- `ratatui 0.30` — TUI rendering; use `Frame::render_widget()`, not direct buffer writes
+- `crossterm 0.29` — terminal backend and key events; `KeyEventKind::Press` only
 - `hidapi 2.4` (linux-native feature) — HID device open/read/write via `/dev/hidrawN`
-- `cpal 0.15` — audio capture for the input level meter; default input device only
+- `cpal 0.17` — audio capture for the input level meter; default input device only
 - `libc 0.2` — stderr suppression during cpal ALSA/JACK probing (`dup`/`dup2`)
 - `anyhow` — all fallible functions return `anyhow::Result`
-- `clap 4.4` — CLI argument parsing; `derive` feature only
+- `clap 4.5` — CLI argument parsing; `derive` feature only
+- `serde 1` (with `derive` feature) — serialisation traits for preset TOML files
+- `toml 0.8` — TOML serialisation/deserialisation for preset files
+- `dirs-next 2.0` — platform config directory resolution (`~/.config/` on Linux)
+- `tempfile 3` (dev-dependency) — hermetic temp directories in `presets.rs` tests
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ Suggesting improvements:
 - Validate all packet arguments before encoding (clamp ranges, not panic)
 - No secrets in source — if a config file is added, use environment variables or `~/.config/`
 - Never write firmware update packets — the firmware update byte sequences are intentionally
-  omitted from this codebase (see README legal section)
+  omitted from this codebase (see readme legal section)
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shurectl"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "shurectl — TUI configurator for the Shure MVX2U audio interface on Linux"
 
@@ -16,6 +16,12 @@ anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 cpal = "0.17"
 libc = "0.2"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+dirs-next = "2.0"
+
+[dev-dependencies]
+tempfile = "3"
 
 [profile.release]
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ interface on Linux. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
 - **Monitor Mix** — mic vs. playback blend slider
 - **5-band Parametric EQ** — per-band enable, gain (−8 to +6 dB in 2 dB steps)
 - **Limiter** — enable/disable
-- **Compressor** — Off / Light / Medium / Heavy presets
+- **Compressor** — Off / Light / Medium / Heavy
 - **High-Pass Filter** — Off / 75 Hz / 150 Hz
-- **4 Preset Slots** — save and load device presets - Work In Progress!
+- **Panel Lock** — lock the physical panel controls on the device
+- **Auto Level controls** — mic position (Near/Far), tone (Dark/Natural/Bright), gain environment (Quiet/Normal/Loud)
+- **4 Preset Slots** — save and load named presets stored as TOML in `~/.config/shurectl/presets/`
 - **Real-time Level Meter** — dBFS input meter with peak-hold display
 - **Device Info** — firmware version, serial number
 - **Demo mode** — run without a device plugged in (`--demo`)
@@ -29,7 +31,7 @@ Settings persist on the device after disconnect (no host software needed after c
 ## Requirements
 
 - Linux (kernel ≥ 4.0)
-- Rust ≥ 1.75 (`rustup` recommended, see below)
+- Rust ≥ 1.85 (`rustup` recommended, see below)
 - `libhidapi-dev` and `libudev-dev`
 
 ```bash
@@ -133,8 +135,34 @@ shurectl --list       # List detected MVX2U devices and exit
 | `→` / `l` | Increase value |
 | `Enter` / `Space` | Toggle boolean / cycle option |
 | `r` | Refresh state from device |
+| `s` | Save preset (on Presets tab, focused slot) |
+| `d` | Delete preset (on Presets tab, focused slot) |
 | `?` | Toggle help overlay |
 | `q` / `Ctrl+C` | Quit |
+
+---
+
+## Presets
+
+Presets are stored as human-readable TOML files in `~/.config/shurectl/presets/`:
+
+```
+~/.config/shurectl/presets/
+├── preset_1.toml
+├── preset_2.toml
+├── preset_3.toml
+└── preset_4.toml
+```
+
+Each file captures all configurable DSP settings (gain, mode, EQ, dynamics, monitor mix, etc.)
+but not hardware-identity fields like serial number or firmware version. Files are hand-editable.
+
+On the **Presets tab**:
+- Navigate to a slot with `↑`/`↓`
+- Press `Enter` on the name field to rename it (type, then `Enter` to confirm or `Esc` to cancel)
+- Press `Enter` on the actions row to load a filled preset — all settings are applied to the device immediately
+- Press `s` to save the current device state into the focused slot
+- Press `d` to delete the focused slot
 
 ---
 
@@ -146,6 +174,7 @@ src/
 ├── app.rs        — Application state, focus/tab navigation, DeviceAction events
 ├── device.rs     — hidapi wrapper; open/send/receive for MVX2U
 ├── meter.rs      — cpal audio capture; real-time dBFS metering, RollingWindow, PeakWindow
+├── presets.rs    — Host-side preset storage: TOML serialisation, load/save/delete, PresetSlot
 ├── protocol.rs   — USB HID packet encoding, CRC-16/ANSI, command constructors, apply_response()
 └── ui.rs         — ratatui TUI rendering (all 5 tabs + help overlay)
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::AtomicI32;
 use std::sync::{Arc, Mutex};
 
 use crate::meter::{METER_SILENT, PeakWindow};
+use crate::presets::{PRESET_COUNT, PresetSlot};
 use crate::protocol::{
     AutoGain, AutoTone, CompressorPreset, DeviceState, HpfFrequency, InputMode, MicPosition,
 };
@@ -76,8 +77,9 @@ pub enum Focus {
     Limiter,
     Compressor,
     Hpf,
-    // Presets tab
-    PresetSlot(usize),
+    // Presets tab — usize is slot index 0–3
+    PresetName(usize),
+    PresetActions(usize),
     // Info — no interactive focus
     None,
 }
@@ -93,6 +95,12 @@ pub struct App {
     pub should_quit: bool,
     pub demo_mode: bool,
     pub help_visible: bool,
+    /// Loaded preset slots. `None` means the slot file does not exist yet.
+    pub presets: [Option<PresetSlot>; PRESET_COUNT],
+    /// Set to `true` while the user is typing a new name for a preset slot.
+    pub editing_preset_name: bool,
+    /// Which slot index is being edited (valid when `editing_preset_name` is true).
+    pub editing_preset_index: usize,
     /// Instantaneous peak level shared with the cpal capture thread.
     /// Stores `peak_dbfs * 10` as i32, or `METER_SILENT` when unavailable.
     pub meter_level: Arc<AtomicI32>,
@@ -106,13 +114,16 @@ impl Default for App {
         Self {
             device_state: DeviceState::default(),
             active_tab: Tab::Main,
-            focus: Focus::Gain,
+            focus: Focus::Mode,
             status_message: String::from("Press ? for help"),
             status_is_error: false,
             eq_selected_band: 0,
             should_quit: false,
             demo_mode: false,
             help_visible: false,
+            presets: [None, None, None, None],
+            editing_preset_name: false,
+            editing_preset_index: 0,
             meter_level: Arc::new(AtomicI32::new(METER_SILENT)),
             peak_window: Arc::new(Mutex::new(PeakWindow::new())),
         }
@@ -173,45 +184,43 @@ impl App {
 
     fn reset_focus_for_tab(&mut self) {
         self.focus = match self.active_tab {
-            Tab::Main => match self.device_state.mode {
-                InputMode::Auto => Focus::Mode,
-                InputMode::Manual => Focus::Gain,
-            },
+            Tab::Main => Focus::Mode,
             Tab::Eq => Focus::EqEnable,
             Tab::Dynamics => Focus::Limiter,
-            Tab::Presets => Focus::PresetSlot(0),
+            Tab::Presets => Focus::PresetName(0),
             Tab::Info => Focus::None,
         };
     }
 
     // ── Focus cycling within a tab ────────────────────────────────────────────
     //
-    // Main tab has two distinct cycles depending on input mode:
+    // Main tab has two distinct cycles depending on input mode.
+    // Order matches top-to-bottom screen layout:
     //
-    //   Manual: Gain → Mode → Mute → Phantom → Lock → MonitorMix → (wrap)
-    //   Auto:   Mode → AutoPosition → AutoTone → AutoGain → Mute → Phantom → Lock → MonitorMix → (wrap)
+    //   Manual: Mode → Mute → Gain → MonitorMix → Phantom → Lock → (wrap)
+    //   Auto:   Mode → Mute → AutoPosition → AutoTone → AutoGain → MonitorMix → Phantom → Lock → (wrap)
     //
     // If focus lands on a mode-specific control while the mode doesn't match
     // (e.g. user toggles mode while focused on Gain), the wildcard arm catches
     // it and returns to the correct starting focus for the current mode.
     pub fn focus_next(&mut self) {
         self.focus = match (&self.active_tab, &self.focus, &self.device_state.mode) {
-            // Manual cycle
-            (Tab::Main, Focus::Gain, InputMode::Manual) => Focus::Mode,
+            // Manual cycle (top → bottom): Mode → Mute → Gain → MonitorMix → Phantom → Lock
             (Tab::Main, Focus::Mode, InputMode::Manual) => Focus::Mute,
-            // Auto cycle
-            (Tab::Main, Focus::Mode, InputMode::Auto) => Focus::AutoPosition,
+            (Tab::Main, Focus::Mute, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, Focus::Gain, InputMode::Manual) => Focus::MonitorMix,
+            // Auto cycle (top → bottom): Mode → Mute → AutoPosition → AutoTone → AutoGain → MonitorMix → Phantom → Lock
+            (Tab::Main, Focus::Mode, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::Mute, InputMode::Auto) => Focus::AutoPosition,
             (Tab::Main, Focus::AutoPosition, InputMode::Auto) => Focus::AutoTone,
             (Tab::Main, Focus::AutoTone, InputMode::Auto) => Focus::AutoGain,
-            (Tab::Main, Focus::AutoGain, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::AutoGain, InputMode::Auto) => Focus::MonitorMix,
             // Shared tail (both modes)
-            (Tab::Main, Focus::Mute, _) => Focus::Phantom,
+            (Tab::Main, Focus::MonitorMix, _) => Focus::Phantom,
             (Tab::Main, Focus::Phantom, _) => Focus::Lock,
-            (Tab::Main, Focus::Lock, _) => Focus::MonitorMix,
-            (Tab::Main, Focus::MonitorMix, InputMode::Manual) => Focus::Gain,
-            (Tab::Main, Focus::MonitorMix, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, Focus::Lock, _) => Focus::Mode,
             // Fallback — wrong-mode focus or unexpected state
-            (Tab::Main, _, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, _, InputMode::Manual) => Focus::Mode,
             (Tab::Main, _, InputMode::Auto) => Focus::Mode,
 
             (Tab::Eq, Focus::EqEnable, _) => Focus::EqBandSelect,
@@ -225,8 +234,9 @@ impl App {
             (Tab::Dynamics, Focus::Hpf, _) => Focus::Limiter,
             (Tab::Dynamics, _, _) => Focus::Limiter,
 
-            (Tab::Presets, Focus::PresetSlot(i), _) => Focus::PresetSlot((*i + 1) % 4),
-            (Tab::Presets, _, _) => Focus::PresetSlot(0),
+            (Tab::Presets, Focus::PresetName(i), _) => Focus::PresetActions(*i),
+            (Tab::Presets, Focus::PresetActions(i), _) => Focus::PresetName((i + 1) % PRESET_COUNT),
+            (Tab::Presets, _, _) => Focus::PresetName(0),
 
             _ => self.focus,
         };
@@ -234,22 +244,23 @@ impl App {
 
     pub fn focus_prev(&mut self) {
         self.focus = match (&self.active_tab, &self.focus, &self.device_state.mode) {
-            // Manual cycle
-            (Tab::Main, Focus::Gain, InputMode::Manual) => Focus::MonitorMix,
-            (Tab::Main, Focus::Mode, InputMode::Manual) => Focus::Gain,
-            // Auto cycle
-            (Tab::Main, Focus::Mode, InputMode::Auto) => Focus::MonitorMix,
-            (Tab::Main, Focus::AutoPosition, InputMode::Auto) => Focus::Mode,
+            // Manual cycle reverse
+            (Tab::Main, Focus::Mode, InputMode::Manual) => Focus::Lock,
+            (Tab::Main, Focus::Mute, InputMode::Manual) => Focus::Mode,
+            (Tab::Main, Focus::Gain, InputMode::Manual) => Focus::Mute,
+            // Auto cycle reverse
+            (Tab::Main, Focus::Mode, InputMode::Auto) => Focus::Lock,
+            (Tab::Main, Focus::Mute, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, Focus::AutoPosition, InputMode::Auto) => Focus::Mute,
             (Tab::Main, Focus::AutoTone, InputMode::Auto) => Focus::AutoPosition,
             (Tab::Main, Focus::AutoGain, InputMode::Auto) => Focus::AutoTone,
             // Shared tail (both modes)
-            (Tab::Main, Focus::Mute, InputMode::Manual) => Focus::Mode,
-            (Tab::Main, Focus::Mute, InputMode::Auto) => Focus::AutoGain,
-            (Tab::Main, Focus::Phantom, _) => Focus::Mute,
+            (Tab::Main, Focus::MonitorMix, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, Focus::MonitorMix, InputMode::Auto) => Focus::AutoGain,
+            (Tab::Main, Focus::Phantom, _) => Focus::MonitorMix,
             (Tab::Main, Focus::Lock, _) => Focus::Phantom,
-            (Tab::Main, Focus::MonitorMix, _) => Focus::Lock,
             // Fallback
-            (Tab::Main, _, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, _, InputMode::Manual) => Focus::Mode,
             (Tab::Main, _, InputMode::Auto) => Focus::Mode,
 
             (Tab::Eq, Focus::EqEnable, _) => Focus::EqGain(self.eq_selected_band),
@@ -263,9 +274,10 @@ impl App {
             (Tab::Dynamics, Focus::Hpf, _) => Focus::Compressor,
             (Tab::Dynamics, _, _) => Focus::Limiter,
 
-            (Tab::Presets, Focus::PresetSlot(0), _) => Focus::PresetSlot(3),
-            (Tab::Presets, Focus::PresetSlot(i), _) if *i > 0 => Focus::PresetSlot(i - 1),
-            (Tab::Presets, _, _) => Focus::PresetSlot(0),
+            (Tab::Presets, Focus::PresetName(0), _) => Focus::PresetActions(PRESET_COUNT - 1),
+            (Tab::Presets, Focus::PresetName(i), _) => Focus::PresetActions(i - 1),
+            (Tab::Presets, Focus::PresetActions(i), _) => Focus::PresetName(*i),
+            (Tab::Presets, _, _) => Focus::PresetName(0),
 
             _ => self.focus,
         };
@@ -377,6 +389,14 @@ impl App {
                 self.device_state.hpf = self.device_state.hpf.cycle_next();
                 Some(DeviceAction::SetHpf(self.device_state.hpf))
             }
+            Focus::PresetActions(i) => {
+                // Enter on the actions row loads the preset (if filled).
+                if self.presets[i].is_some() {
+                    Some(DeviceAction::LoadPreset(i))
+                } else {
+                    None
+                }
+            }
             _ => None,
         }
     }
@@ -403,6 +423,14 @@ pub enum DeviceAction {
     SetEqBandEnable(usize, bool),
     /// `usize` is band index 0–4; `i8` is gain in dB (−8..+6, steps of 2).
     SetEqBandGain(usize, i8),
+    /// Save current device state to preset slot `usize`.
+    SavePreset(usize),
+    /// Load preset slot `usize` and apply all settings to the device.
+    LoadPreset(usize),
+    /// Delete the preset file for slot `usize`.
+    DeletePreset(usize),
+    /// Write the (already in-memory-updated) preset name for slot `usize` back to disk.
+    PersistPresetName(usize),
     Refresh,
 }
 
@@ -478,7 +506,7 @@ mod tests {
         let expected: &[(Tab, Focus)] = &[
             (Tab::Eq, Focus::EqEnable),
             (Tab::Dynamics, Focus::Limiter),
-            (Tab::Presets, Focus::PresetSlot(0)),
+            (Tab::Presets, Focus::PresetName(0)),
             (Tab::Info, Focus::None),
         ];
         for (tab, expected_focus) in expected {
@@ -585,44 +613,44 @@ mod tests {
 
     #[test]
     fn main_tab_manual_mode_focus_cycles_forward_and_back() {
-        // Manual: Gain → Mode → Mute → Phantom → Lock → MonitorMix → Gain
+        // Manual: Mode → Mute → Gain → MonitorMix → Phantom → Lock → Mode
         let forward = [
-            Focus::Gain,
             Focus::Mode,
             Focus::Mute,
+            Focus::Gain,
+            Focus::MonitorMix,
             Focus::Phantom,
             Focus::Lock,
-            Focus::MonitorMix,
-            Focus::Gain, // wrap
+            Focus::Mode, // wrap
         ];
         let mut app = App::default();
         app.active_tab = Tab::Main;
         app.device_state.mode = InputMode::Manual;
-        app.focus = Focus::Gain;
+        app.focus = Focus::Mode;
 
         for expected in &forward[1..] {
             app.focus_next();
             assert_eq!(app.focus, *expected);
         }
 
-        // Backward from Gain wraps to MonitorMix
-        app.focus = Focus::Gain;
+        // Backward from Mode wraps to Lock
+        app.focus = Focus::Mode;
         app.focus_prev();
-        assert_eq!(app.focus, Focus::MonitorMix);
+        assert_eq!(app.focus, Focus::Lock);
     }
 
     #[test]
     fn main_tab_auto_mode_focus_cycles_forward_and_back() {
-        // Auto: Mode → AutoPosition → AutoTone → AutoGain → Mute → Phantom → Lock → MonitorMix → Mode
+        // Auto: Mode → Mute → AutoPosition → AutoTone → AutoGain → MonitorMix → Phantom → Lock → Mode
         let forward = [
             Focus::Mode,
+            Focus::Mute,
             Focus::AutoPosition,
             Focus::AutoTone,
             Focus::AutoGain,
-            Focus::Mute,
+            Focus::MonitorMix,
             Focus::Phantom,
             Focus::Lock,
-            Focus::MonitorMix,
             Focus::Mode, // wrap
         ];
         let mut app = App::default();
@@ -635,10 +663,10 @@ mod tests {
             assert_eq!(app.focus, *expected);
         }
 
-        // Backward from Mode wraps to MonitorMix
+        // Backward from Mode wraps to Lock
         app.focus = Focus::Mode;
         app.focus_prev();
-        assert_eq!(app.focus, Focus::MonitorMix);
+        assert_eq!(app.focus, Focus::Lock);
     }
 
     #[test]
@@ -660,25 +688,43 @@ mod tests {
     }
 
     #[test]
-    fn presets_tab_focus_wraps_at_slot_boundaries() {
+    fn presets_tab_focus_cycles_through_name_and_actions_rows() {
         let mut app = App::default();
         app.active_tab = Tab::Presets;
-        app.focus = Focus::PresetSlot(3);
 
-        app.focus_next();
-        assert_eq!(
-            app.focus,
-            Focus::PresetSlot(0),
-            "slot 3 next should wrap to slot 0"
-        );
+        // Walk forward through all slots: Name(0) → Actions(0) → Name(1) → ... → Actions(3) → Name(0)
+        app.focus = Focus::PresetName(0);
+        let expected_forward = [
+            Focus::PresetActions(0),
+            Focus::PresetName(1),
+            Focus::PresetActions(1),
+            Focus::PresetName(2),
+            Focus::PresetActions(2),
+            Focus::PresetName(3),
+            Focus::PresetActions(3),
+            Focus::PresetName(0), // wraps
+        ];
+        for expected in expected_forward {
+            app.focus_next();
+            assert_eq!(app.focus, expected, "focus_next mismatch");
+        }
 
-        app.focus = Focus::PresetSlot(0);
-        app.focus_prev();
-        assert_eq!(
-            app.focus,
-            Focus::PresetSlot(3),
-            "slot 0 prev should wrap to slot 3"
-        );
+        // Walk backward: Actions(3) → Name(3) → Actions(2) → ... → Name(0) → Actions(3)
+        app.focus = Focus::PresetActions(3);
+        let expected_backward = [
+            Focus::PresetName(3),
+            Focus::PresetActions(2),
+            Focus::PresetName(2),
+            Focus::PresetActions(1),
+            Focus::PresetName(1),
+            Focus::PresetActions(0),
+            Focus::PresetName(0),
+            Focus::PresetActions(3), // wraps
+        ];
+        for expected in expected_backward {
+            app.focus_prev();
+            assert_eq!(app.focus, expected, "focus_prev mismatch");
+        }
     }
 
     // ── adjust_focused ────────────────────────────────────────────────────────
@@ -968,6 +1014,10 @@ mod tests {
             Focus::MonitorMix,
             Focus::EqBandSelect,
             Focus::None,
+            // PresetName: editing is handled in handle_key, not toggle_focused
+            Focus::PresetName(0),
+            // PresetActions with empty slot: no preset to load
+            Focus::PresetActions(0),
         ] {
             app.focus = focus;
             assert!(
@@ -1026,6 +1076,45 @@ mod tests {
             app.peak_window.lock().unwrap().short.max(),
             Some(-200),
             "write through a cloned Arc must be visible via app.peak_window"
+        );
+    }
+
+    // ── preset focus / toggle ─────────────────────────────────────────────────
+
+    #[test]
+    fn toggle_preset_actions_filled_returns_load_preset() {
+        let mut app = App::default();
+        app.active_tab = Tab::Presets;
+        app.focus = Focus::PresetActions(2);
+        // Populate slot 2 with a minimal preset.
+        use crate::presets::{
+            PresetSlot, SerAutoGain, SerAutoTone, SerCompressorPreset, SerEqBand, SerHpfFrequency,
+            SerInputMode, SerMicPosition,
+        };
+        app.presets[2] = Some(PresetSlot {
+            name: String::from("Test"),
+            gain_db: 36,
+            mode: SerInputMode::Manual,
+            auto_position: SerMicPosition::Near,
+            auto_tone: SerAutoTone::Natural,
+            auto_gain: SerAutoGain::Normal,
+            muted: false,
+            phantom_power: false,
+            monitor_mix: 0,
+            limiter_enabled: false,
+            compressor: SerCompressorPreset::Off,
+            hpf: SerHpfFrequency::Off,
+            eq_enabled: false,
+            eq_bands: [SerEqBand {
+                enabled: false,
+                gain_db: 0,
+            }; 5],
+        });
+
+        let action = app.toggle_focused();
+        assert!(
+            matches!(action, Some(DeviceAction::LoadPreset(2))),
+            "filled PresetActions slot must return LoadPreset"
         );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -184,7 +184,10 @@ impl App {
 
     fn reset_focus_for_tab(&mut self) {
         self.focus = match self.active_tab {
-            Tab::Main => Focus::Mode,
+            Tab::Main => match self.device_state.mode {
+                InputMode::Manual => Focus::Gain,
+                InputMode::Auto => Focus::Mode,
+            },
             Tab::Eq => Focus::EqEnable,
             Tab::Dynamics => Focus::Limiter,
             Tab::Presets => Focus::PresetName(0),

--- a/src/device.rs
+++ b/src/device.rs
@@ -25,7 +25,6 @@
 //! device echoes this number in its response. We track it in `Mvx2u` and
 //! increment after every `write()`.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
 
 use anyhow::{Context, Result, anyhow};
@@ -44,9 +43,8 @@ const READ_TIMEOUT_MS: i32 = 200;
 
 pub struct Mvx2u {
     device: HidDevice,
-    /// Packet sequence number, shared so callers can read it for diagnostics.
-    /// Increments after every write.
-    seq: Arc<AtomicU8>,
+    /// Packet sequence number. Increments after every write; wraps at 256.
+    seq: AtomicU8,
     /// Serial number string read from the USB device descriptor at open time.
     pub serial_number: String,
 }
@@ -75,7 +73,7 @@ impl Mvx2u {
             .unwrap_or_else(|| "(unknown)".to_string());
         Ok(Self {
             device,
-            seq: Arc::new(AtomicU8::new(0)),
+            seq: AtomicU8::new(0),
             serial_number,
         })
     }
@@ -262,7 +260,7 @@ impl Mvx2u {
         ))
     }
 
-    /// Set an EQ band's gain (−12 to +12 dB). `band` is 0–4.
+    /// Set an EQ band's gain (−8 to +6 dB, steps of 2). `band` is 0–4.
     pub fn set_eq_band_gain(&self, band: usize, gain_db: i8) -> Result<()> {
         self.send_set(&protocol::cmd_set_eq_band_gain(
             self.next_seq(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@
 mod app;
 mod device;
 mod meter;
+mod presets;
 mod protocol;
 mod ui;
 
@@ -31,6 +32,7 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 use app::{App, DeviceAction};
 use device::Mvx2u;
 use meter::{MeterStatus, start_meter};
+use presets::PresetSlot;
 use protocol::InputMode;
 
 #[derive(Parser)]
@@ -97,6 +99,8 @@ fn main() -> Result<()> {
     } else {
         app.set_ok("Demo mode — changes will not be sent to a device.");
     }
+
+    app.presets = presets::load_all_presets();
 
     // Start the input level meter. _meter_stream must stay alive —
     // dropping it stops the capture thread.
@@ -174,7 +178,41 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
     if matches!(code, KeyCode::Char('q') | KeyCode::Char('Q'))
         || (code == KeyCode::Char('c') && mods.contains(KeyModifiers::CONTROL))
     {
-        app.should_quit = true;
+        // Quit is blocked while editing a preset name — Esc must be used first.
+        if !app.editing_preset_name {
+            app.should_quit = true;
+        }
+        return None;
+    }
+
+    // ── Preset name editing mode ──────────────────────────────────────────────
+    if app.editing_preset_name {
+        match code {
+            KeyCode::Enter | KeyCode::Esc => {
+                app.editing_preset_name = false;
+                let i = app.editing_preset_index;
+                // Persist the updated name if the slot is filled.
+                if app.presets[i].is_some() {
+                    return Some(DeviceAction::PersistPresetName(i));
+                }
+            }
+            KeyCode::Backspace => {
+                let i = app.editing_preset_index;
+                if let Some(slot) = &mut app.presets[i] {
+                    slot.name.pop();
+                }
+            }
+            KeyCode::Char(c) if !mods.contains(KeyModifiers::CONTROL) => {
+                let i = app.editing_preset_index;
+                if let Some(slot) = &mut app.presets[i] {
+                    // Cap name length at 40 characters.
+                    if slot.name.len() < 40 {
+                        slot.name.push(c);
+                    }
+                }
+            }
+            _ => {}
+        }
         return None;
     }
 
@@ -209,7 +247,36 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
         }
         KeyCode::Left | KeyCode::Char('h') => app.adjust_focused(-1),
         KeyCode::Right | KeyCode::Char('l') => app.adjust_focused(1),
-        KeyCode::Enter | KeyCode::Char(' ') => app.toggle_focused(),
+        KeyCode::Enter | KeyCode::Char(' ') => {
+            // On PresetName: enter edit mode.
+            if let app::Focus::PresetName(i) = app.focus
+                && app.presets[i].is_some()
+            {
+                app.editing_preset_name = true;
+                app.editing_preset_index = i;
+                return None;
+            }
+            app.toggle_focused()
+        }
+        // Preset-specific keys — only active on the Presets tab.
+        KeyCode::Char('s') if app.active_tab == app::Tab::Presets => {
+            if let app::Focus::PresetName(i) | app::Focus::PresetActions(i) = app.focus {
+                Some(DeviceAction::SavePreset(i))
+            } else {
+                None
+            }
+        }
+        KeyCode::Char('d') | KeyCode::Delete if app.active_tab == app::Tab::Presets => {
+            if let app::Focus::PresetActions(i) = app.focus {
+                if app.presets[i].is_some() {
+                    Some(DeviceAction::DeletePreset(i))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
         _ => None,
     }
 }
@@ -300,6 +367,57 @@ fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
             app.set_ok(format!("EQ Band {} → {:+} dB", band + 1, gain_db));
             send_if_connected(device, |d| d.set_eq_band_gain(*band, *gain_db))
         }
+        DeviceAction::SavePreset(i) => {
+            let name = app.presets[*i]
+                .as_ref()
+                .map(|s| s.name.clone())
+                .unwrap_or_else(|| format!("Preset {}", i + 1));
+            let slot = PresetSlot::from_device_state(name, &app.device_state);
+            match presets::save_preset(*i, &slot) {
+                Ok(()) => {
+                    app.set_ok(format!("Saved to \"{}\".", slot.name));
+                    app.presets[*i] = Some(slot);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        }
+        DeviceAction::LoadPreset(i) => {
+            if let Some(slot) = &app.presets[*i].clone() {
+                slot.apply_to_device_state(&mut app.device_state);
+                app.set_ok(format!("Loaded \"{}\".", slot.name));
+                // Apply every setting to the device.
+                apply_preset_to_device(device, &app.device_state)
+            } else {
+                app.set_err(format!("Preset slot {} is empty.", i + 1));
+                Ok(())
+            }
+        }
+        DeviceAction::DeletePreset(i) => match presets::delete_preset(*i) {
+            Ok(()) => {
+                let name = app.presets[*i]
+                    .as_ref()
+                    .map(|s| s.name.as_str())
+                    .unwrap_or("preset");
+                app.set_ok(format!("Deleted \"{}\".", name));
+                app.presets[*i] = None;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        },
+        DeviceAction::PersistPresetName(i) => {
+            if let Some(slot) = &app.presets[*i] {
+                match presets::save_preset(*i, slot) {
+                    Ok(()) => {
+                        app.set_ok(format!("Renamed to \"{}\".", slot.name));
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
+            } else {
+                Ok(())
+            }
+        }
     };
 
     if let Err(e) = result {
@@ -315,4 +433,28 @@ where
         Some(dev) => f(dev),
         None => Ok(()),
     }
+}
+
+/// Send every configurable field of `state` to the device.
+/// Called after loading a preset to bring the hardware into sync.
+fn apply_preset_to_device(device: &Option<Mvx2u>, state: &protocol::DeviceState) -> Result<()> {
+    send_if_connected(device, |d| {
+        d.set_mode(state.mode == InputMode::Auto)?;
+        d.set_gain(state.gain_db)?;
+        d.set_auto_position(&state.auto_position)?;
+        d.set_auto_tone(&state.auto_tone)?;
+        d.set_auto_gain(&state.auto_gain)?;
+        d.set_mute(state.muted)?;
+        d.set_phantom(state.phantom_power)?;
+        d.set_monitor_mix(state.monitor_mix)?;
+        d.set_limiter(state.limiter_enabled)?;
+        d.set_compressor(&state.compressor)?;
+        d.set_hpf(&state.hpf)?;
+        d.set_eq_enable(state.eq_enabled)?;
+        for (band, eq) in state.eq_bands.iter().enumerate() {
+            d.set_eq_band_enable(band, eq.enabled)?;
+            d.set_eq_band_gain(band, eq.gain_db)?;
+        }
+        Ok(())
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,11 +320,11 @@ fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
             send_if_connected(device, |d| d.set_auto_gain(gain))
         }
         DeviceAction::SetMute(m) => {
-            app.set_ok(format!("Mute → {}", if *m { "ON" } else { "Off" }));
+            app.set_ok(format!("Mute → {}", if *m { "ON" } else { "OFF" }));
             send_if_connected(device, |d| d.set_mute(*m))
         }
         DeviceAction::SetPhantom(p) => {
-            app.set_ok(format!("Phantom → {}", if *p { "48V ON" } else { "Off" }));
+            app.set_ok(format!("Phantom → {}", if *p { "48V ON" } else { "OFF" }));
             send_if_connected(device, |d| d.set_phantom(*p))
         }
         DeviceAction::SetLock(locked) => {
@@ -340,7 +340,7 @@ fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
             send_if_connected(device, |d| d.set_monitor_mix(*m))
         }
         DeviceAction::SetLimiter(en) => {
-            app.set_ok(format!("Limiter → {}", if *en { "ON" } else { "Off" }));
+            app.set_ok(format!("Limiter → {}", if *en { "ON" } else { "OFF" }));
             send_if_connected(device, |d| d.set_limiter(*en))
         }
         DeviceAction::SetCompressor(preset) => {
@@ -359,7 +359,7 @@ fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
             app.set_ok(format!(
                 "EQ Band {} → {}",
                 band + 1,
-                if *en { "ON" } else { "Off" }
+                if *en { "ON" } else { "OFF" }
             ));
             send_if_connected(device, |d| d.set_eq_band_enable(*band, *en))
         }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -1,0 +1,526 @@
+//! Host-side preset storage for shurectl.
+//!
+//! Presets are TOML files stored in `~/.config/shurectl/presets/`.
+//! There are 4 fixed slots, numbered 0–3, stored as `preset_1.toml`–`preset_4.toml`.
+//!
+//! Each file is human-readable and hand-editable. The preset captures all
+//! configurable DSP settings from `DeviceState` — everything that can be sent
+//! to the MVX2U over HID. Hardware-identity fields `serial_number` are intentionally excluded.
+//!
+//! This mirrors how MOTIV Desktop saves presets: the app sends a batch of SET
+//! commands when a preset is loaded, with no device-side preset bank involved.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::{
+    AutoGain, AutoTone, CompressorPreset, DeviceState, EqBand, HpfFrequency, InputMode, MicPosition,
+};
+
+pub const PRESET_COUNT: usize = 4;
+
+/// A serializable snapshot of all configurable device settings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PresetSlot {
+    /// Human-readable name shown in the TUI (editable in-app or by hand in TOML).
+    pub name: String,
+
+    // ── Main ─────────────────────────────────────────────────────────────────
+    pub gain_db: u8,
+    pub mode: SerInputMode,
+    pub auto_position: SerMicPosition,
+    pub auto_tone: SerAutoTone,
+    pub auto_gain: SerAutoGain,
+    pub muted: bool,
+    pub phantom_power: bool,
+    /// Monitor mix: 0 = 100% mic, 100 = 100% playback.
+    pub monitor_mix: u8,
+
+    // ── Dynamics ─────────────────────────────────────────────────────────────
+    pub limiter_enabled: bool,
+    pub compressor: SerCompressorPreset,
+    pub hpf: SerHpfFrequency,
+
+    // ── EQ ───────────────────────────────────────────────────────────────────
+    pub eq_enabled: bool,
+    pub eq_bands: [SerEqBand; 5],
+}
+
+impl PresetSlot {
+    /// Build a preset snapshot from a live `DeviceState`.
+    pub fn from_device_state(name: impl Into<String>, state: &DeviceState) -> Self {
+        Self {
+            name: name.into(),
+            gain_db: state.gain_db,
+            mode: SerInputMode::from(state.mode),
+            auto_position: SerMicPosition::from(state.auto_position),
+            auto_tone: SerAutoTone::from(state.auto_tone),
+            auto_gain: SerAutoGain::from(state.auto_gain),
+            muted: state.muted,
+            phantom_power: state.phantom_power,
+            monitor_mix: state.monitor_mix,
+            limiter_enabled: state.limiter_enabled,
+            compressor: SerCompressorPreset::from(state.compressor),
+            hpf: SerHpfFrequency::from(state.hpf),
+            eq_enabled: state.eq_enabled,
+            eq_bands: state.eq_bands.map(SerEqBand::from),
+        }
+    }
+
+    /// Apply this preset's settings onto a `DeviceState`, preserving
+    /// hardware-identity fields (`serial_number`).
+    pub fn apply_to_device_state(&self, state: &mut DeviceState) {
+        state.gain_db = self.gain_db;
+        state.mode = InputMode::from(self.mode);
+        state.auto_position = MicPosition::from(self.auto_position);
+        state.auto_tone = AutoTone::from(self.auto_tone);
+        state.auto_gain = AutoGain::from(self.auto_gain);
+        state.muted = self.muted;
+        state.phantom_power = self.phantom_power;
+        state.monitor_mix = self.monitor_mix;
+        state.limiter_enabled = self.limiter_enabled;
+        state.compressor = CompressorPreset::from(self.compressor);
+        state.hpf = HpfFrequency::from(self.hpf);
+        state.eq_enabled = self.eq_enabled;
+        state.eq_bands = self.eq_bands.map(EqBand::from);
+    }
+
+    /// One-line summary of the key settings for display in the TUI.
+    pub fn summary(&self) -> String {
+        let phantom_str = if self.phantom_power {
+            "48V on"
+        } else {
+            "48V off"
+        };
+        match InputMode::from(self.mode) {
+            InputMode::Auto => {
+                let tone = AutoTone::from(self.auto_tone);
+                let gain = AutoGain::from(self.auto_gain);
+                let pos = MicPosition::from(self.auto_position);
+                format!("Auto · {tone} · {gain} · {pos} · {phantom_str}")
+            }
+            InputMode::Manual => {
+                let eq_str = if self.eq_enabled { "EQ on" } else { "EQ off" };
+                let comp_str = CompressorPreset::from(self.compressor).to_string();
+                let hpf_str = match HpfFrequency::from(self.hpf) {
+                    HpfFrequency::Off => "HPF off".to_string(),
+                    freq => format!("HPF {freq}"),
+                };
+                format!(
+                    "Manual · {}dB · {eq_str} · Comp: {comp_str} · {phantom_str} · {hpf_str}",
+                    self.gain_db
+                )
+            }
+        }
+    }
+}
+
+// ── File I/O ──────────────────────────────────────────────────────────────────
+
+/// Returns `~/.config/shurectl/presets/`, creating it if absent.
+fn presets_dir() -> Result<PathBuf> {
+    let base = dirs_next::config_dir()
+        .or_else(|| {
+            std::env::var("HOME")
+                .ok()
+                .map(|h| PathBuf::from(h).join(".config"))
+        })
+        .context("Cannot determine config directory; set $HOME")?;
+    let dir = base.join("shurectl").join("presets");
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create preset directory: {}", dir.display()))?;
+    Ok(dir)
+}
+
+/// Returns the path for slot `index` (0-based). File is named `preset_1.toml`–`preset_4.toml`.
+pub fn preset_path(index: usize) -> Result<PathBuf> {
+    Ok(presets_dir()?.join(format!("preset_{}.toml", index + 1)))
+}
+
+/// Load the preset at `index`. Returns `None` if the slot file does not exist.
+pub fn load_preset(index: usize) -> Result<Option<PresetSlot>> {
+    let path = preset_path(index)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read preset file: {}", path.display()))?;
+    let slot: PresetSlot = toml::from_str(&text)
+        .with_context(|| format!("Failed to parse preset file: {}", path.display()))?;
+    Ok(Some(slot))
+}
+
+/// Save a preset to slot `index`, overwriting any existing file.
+pub fn save_preset(index: usize, slot: &PresetSlot) -> Result<()> {
+    let path = preset_path(index)?;
+    let text = toml::to_string_pretty(slot).context("Failed to serialise preset")?;
+    std::fs::write(&path, text)
+        .with_context(|| format!("Failed to write preset file: {}", path.display()))?;
+    Ok(())
+}
+
+/// Delete the preset file for slot `index`. No-op if the slot is already empty.
+pub fn delete_preset(index: usize) -> Result<()> {
+    let path = preset_path(index)?;
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .with_context(|| format!("Failed to delete preset file: {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Load all 4 preset slots. Missing files produce `None` entries.
+pub fn load_all_presets() -> [Option<PresetSlot>; PRESET_COUNT] {
+    std::array::from_fn(|i| load_preset(i).unwrap_or(None))
+}
+
+// ── Serialisable mirror types ─────────────────────────────────────────────────
+//
+// We use separate mirror enums with `#[derive(Serialize, Deserialize)]` rather
+// than adding serde derives directly to protocol types. This keeps protocol.rs
+// free of serde concerns and ensures the on-disk format is stable even if the
+// internal enums evolve.
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SerInputMode {
+    Auto,
+    Manual,
+}
+
+impl From<InputMode> for SerInputMode {
+    fn from(v: InputMode) -> Self {
+        match v {
+            InputMode::Auto => Self::Auto,
+            InputMode::Manual => Self::Manual,
+        }
+    }
+}
+
+impl From<SerInputMode> for InputMode {
+    fn from(v: SerInputMode) -> Self {
+        match v {
+            SerInputMode::Auto => Self::Auto,
+            SerInputMode::Manual => Self::Manual,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SerMicPosition {
+    Near,
+    Far,
+}
+
+impl From<MicPosition> for SerMicPosition {
+    fn from(v: MicPosition) -> Self {
+        match v {
+            MicPosition::Near => Self::Near,
+            MicPosition::Far => Self::Far,
+        }
+    }
+}
+
+impl From<SerMicPosition> for MicPosition {
+    fn from(v: SerMicPosition) -> Self {
+        match v {
+            SerMicPosition::Near => Self::Near,
+            SerMicPosition::Far => Self::Far,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SerAutoTone {
+    Dark,
+    Natural,
+    Bright,
+}
+
+impl From<AutoTone> for SerAutoTone {
+    fn from(v: AutoTone) -> Self {
+        match v {
+            AutoTone::Dark => Self::Dark,
+            AutoTone::Natural => Self::Natural,
+            AutoTone::Bright => Self::Bright,
+        }
+    }
+}
+
+impl From<SerAutoTone> for AutoTone {
+    fn from(v: SerAutoTone) -> Self {
+        match v {
+            SerAutoTone::Dark => Self::Dark,
+            SerAutoTone::Natural => Self::Natural,
+            SerAutoTone::Bright => Self::Bright,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SerAutoGain {
+    Quiet,
+    Normal,
+    Loud,
+}
+
+impl From<AutoGain> for SerAutoGain {
+    fn from(v: AutoGain) -> Self {
+        match v {
+            AutoGain::Quiet => Self::Quiet,
+            AutoGain::Normal => Self::Normal,
+            AutoGain::Loud => Self::Loud,
+        }
+    }
+}
+
+impl From<SerAutoGain> for AutoGain {
+    fn from(v: SerAutoGain) -> Self {
+        match v {
+            SerAutoGain::Quiet => Self::Quiet,
+            SerAutoGain::Normal => Self::Normal,
+            SerAutoGain::Loud => Self::Loud,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SerCompressorPreset {
+    Off,
+    Light,
+    Medium,
+    Heavy,
+}
+
+impl From<CompressorPreset> for SerCompressorPreset {
+    fn from(v: CompressorPreset) -> Self {
+        match v {
+            CompressorPreset::Off => Self::Off,
+            CompressorPreset::Light => Self::Light,
+            CompressorPreset::Medium => Self::Medium,
+            CompressorPreset::Heavy => Self::Heavy,
+        }
+    }
+}
+
+impl From<SerCompressorPreset> for CompressorPreset {
+    fn from(v: SerCompressorPreset) -> Self {
+        match v {
+            SerCompressorPreset::Off => Self::Off,
+            SerCompressorPreset::Light => Self::Light,
+            SerCompressorPreset::Medium => Self::Medium,
+            SerCompressorPreset::Heavy => Self::Heavy,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SerHpfFrequency {
+    Off,
+    Hz75,
+    Hz150,
+}
+
+impl From<HpfFrequency> for SerHpfFrequency {
+    fn from(v: HpfFrequency) -> Self {
+        match v {
+            HpfFrequency::Off => Self::Off,
+            HpfFrequency::Hz75 => Self::Hz75,
+            HpfFrequency::Hz150 => Self::Hz150,
+        }
+    }
+}
+
+impl From<SerHpfFrequency> for HpfFrequency {
+    fn from(v: SerHpfFrequency) -> Self {
+        match v {
+            SerHpfFrequency::Off => Self::Off,
+            SerHpfFrequency::Hz75 => Self::Hz75,
+            SerHpfFrequency::Hz150 => Self::Hz150,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SerEqBand {
+    pub enabled: bool,
+    /// Gain in dB, range −8..+6.
+    pub gain_db: i8,
+}
+
+impl From<EqBand> for SerEqBand {
+    fn from(v: EqBand) -> Self {
+        Self {
+            enabled: v.enabled,
+            gain_db: v.gain_db,
+        }
+    }
+}
+
+impl From<SerEqBand> for EqBand {
+    fn from(v: SerEqBand) -> Self {
+        Self {
+            enabled: v.enabled,
+            gain_db: v.gain_db,
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn example_state() -> DeviceState {
+        DeviceState {
+            gain_db: 42,
+            mode: InputMode::Manual,
+            auto_position: MicPosition::Far,
+            auto_tone: AutoTone::Bright,
+            auto_gain: AutoGain::Loud,
+            muted: true,
+            phantom_power: true,
+            monitor_mix: 50,
+            limiter_enabled: true,
+            compressor: CompressorPreset::Medium,
+            hpf: HpfFrequency::Hz75,
+            eq_enabled: true,
+            eq_bands: [
+                EqBand {
+                    enabled: true,
+                    gain_db: 4,
+                },
+                EqBand {
+                    enabled: false,
+                    gain_db: -2,
+                },
+                EqBand {
+                    enabled: true,
+                    gain_db: 0,
+                },
+                EqBand {
+                    enabled: false,
+                    gain_db: 6,
+                },
+                EqBand {
+                    enabled: true,
+                    gain_db: -8,
+                },
+            ],
+            locked: false,
+            serial_number: String::from("TEST001"),
+        }
+    }
+
+    #[test]
+    fn preset_slot_roundtrip_toml() {
+        let state = example_state();
+        let slot = PresetSlot::from_device_state("My Preset", &state);
+
+        let toml_str = toml::to_string_pretty(&slot).expect("serialise");
+        let decoded: PresetSlot = toml::from_str(&toml_str).expect("deserialise");
+
+        assert_eq!(slot, decoded);
+        assert_eq!(decoded.name, "My Preset");
+        assert_eq!(decoded.gain_db, 42);
+        assert_eq!(decoded.muted, true);
+        assert_eq!(decoded.eq_bands[0].gain_db, 4);
+        assert_eq!(decoded.eq_bands[4].gain_db, -8);
+    }
+
+    #[test]
+    fn apply_to_device_state_restores_all_fields() {
+        let original = example_state();
+        let slot = PresetSlot::from_device_state("Test", &original);
+
+        // Apply onto a default state (different values).
+        let mut target = DeviceState::default();
+        // Preserve identity fields to confirm they are NOT overwritten.
+        target.serial_number = String::from("OTHER");
+
+        slot.apply_to_device_state(&mut target);
+
+        assert_eq!(target.gain_db, 42);
+        assert_eq!(target.mode, InputMode::Manual);
+        assert_eq!(target.auto_position, MicPosition::Far);
+        assert_eq!(target.auto_tone, AutoTone::Bright);
+        assert_eq!(target.auto_gain, AutoGain::Loud);
+        assert!(target.muted);
+        assert!(target.phantom_power);
+        assert_eq!(target.monitor_mix, 50);
+        assert!(target.limiter_enabled);
+        assert_eq!(target.compressor, CompressorPreset::Medium);
+        assert_eq!(target.hpf, HpfFrequency::Hz75);
+        assert!(target.eq_enabled);
+        assert_eq!(target.eq_bands[0].gain_db, 4);
+        // Identity fields must be untouched.
+        assert_eq!(target.serial_number, "OTHER");
+    }
+
+    #[test]
+    fn save_and_load_preset_roundtrip() {
+        let state = example_state();
+        let slot = PresetSlot::from_device_state("Roundtrip", &state);
+
+        // Use a temp dir so tests are hermetic.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("preset_1.toml");
+
+        let text = toml::to_string_pretty(&slot).expect("serialise");
+        std::fs::write(&path, &text).expect("write");
+
+        let loaded: PresetSlot =
+            toml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("deserialise");
+
+        assert_eq!(slot, loaded);
+    }
+
+    #[test]
+    fn summary_manual_mode_contains_gain_eq_dynamics_phantom_hpf() {
+        let mut state = example_state();
+        state.mode = InputMode::Manual;
+        state.gain_db = 36;
+        state.phantom_power = true;
+        state.hpf = HpfFrequency::Hz75;
+        let slot = PresetSlot::from_device_state("S", &state);
+        let s = slot.summary();
+        assert!(s.contains("Manual"), "summary: {s}");
+        assert!(s.contains("36dB"), "summary: {s}");
+        assert!(s.contains("EQ"), "summary: {s}");
+        assert!(s.contains("Comp:"), "summary: {s}");
+        assert!(s.contains("48V on"), "summary: {s}");
+        assert!(s.contains("HPF 75 Hz"), "summary: {s}");
+    }
+
+    #[test]
+    fn summary_auto_mode_contains_tone_gain_position_phantom_no_eq_dynamics() {
+        let mut state = example_state();
+        state.mode = InputMode::Auto;
+        state.auto_tone = AutoTone::Natural;
+        state.auto_gain = AutoGain::Normal;
+        state.auto_position = MicPosition::Near;
+        state.phantom_power = false;
+        let slot = PresetSlot::from_device_state("S", &state);
+        let s = slot.summary();
+        assert!(s.contains("Auto"), "summary: {s}");
+        assert!(s.contains("Natural"), "summary: {s}");
+        assert!(s.contains("Normal"), "summary: {s}");
+        assert!(s.contains("Near"), "summary: {s}");
+        assert!(s.contains("48V off"), "summary: {s}");
+        // EQ and Dynamics are not shown in Auto mode
+        assert!(!s.contains("EQ"), "Auto summary must not mention EQ: {s}");
+        assert!(
+            !s.contains("Comp"),
+            "Auto summary must not mention Comp: {s}"
+        );
+        assert!(!s.contains("HPF"), "Auto summary must not mention HPF: {s}");
+    }
+}

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -172,8 +172,15 @@ pub fn delete_preset(index: usize) -> Result<()> {
 }
 
 /// Load all 4 preset slots. Missing files produce `None` entries.
+/// Parse errors are logged to stderr and treated as empty slots.
 pub fn load_all_presets() -> [Option<PresetSlot>; PRESET_COUNT] {
-    std::array::from_fn(|i| load_preset(i).unwrap_or(None))
+    std::array::from_fn(|i| match load_preset(i) {
+        Ok(slot) => slot,
+        Err(e) => {
+            eprintln!("Warning: failed to load preset slot {}: {e}", i + 1);
+            None
+        }
+    })
 }
 
 // ── Serialisable mirror types ─────────────────────────────────────────────────

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -142,8 +142,6 @@ pub struct DeviceState {
     pub locked: bool,
     /// Device serial number string, populated after connection.
     pub serial_number: String,
-    /// Device firmware version string, populated after connection.
-    pub firmware_version: String,
 }
 
 impl Default for DeviceState {
@@ -164,7 +162,6 @@ impl Default for DeviceState {
             eq_bands: [EqBand::default(); 5],
             locked: false,
             serial_number: String::from("Unknown"),
-            firmware_version: String::from("Unknown"),
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -158,15 +158,22 @@ fn draw_status(f: &mut Frame, app: &App, area: Rect) {
         (format!("  {}", app.status_message), C_DIM)
     };
 
-    let help_hint = Span::styled(
-        " [Tab] Next section  [↑↓] Focus  [←→/Enter] Adjust  [r] Refresh  [?] Help  [q] Quit",
-        Style::default().fg(C_DISABLED),
-    );
+    let hint = if app.editing_preset_name {
+        Span::styled(
+            " Editing name — type to change  [Enter/Esc] confirm  [Backspace] delete",
+            Style::default().fg(C_ACCENT),
+        )
+    } else {
+        Span::styled(
+            " [Tab] Next section  [↑↓] Focus  [←→/Enter] Adjust  [r] Refresh  [?] Help  [q] Quit",
+            Style::default().fg(C_DISABLED),
+        )
+    };
 
     let status_line = vec![
         Span::styled(msg, Style::default().fg(color)),
         Span::raw("   "),
-        help_hint,
+        hint,
     ];
 
     f.render_widget(
@@ -634,10 +641,6 @@ fn draw_main_right(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let mut lines = vec![
-        Line::from(vec![
-            Span::styled("Firmware    : ", Style::default().fg(C_DIM)),
-            Span::styled(&*ds.firmware_version, Style::default().fg(C_TEXT)),
-        ]),
         Line::from(""),
         Line::from(vec![
             Span::styled("Mode        : ", Style::default().fg(C_DIM)),
@@ -1289,89 +1292,182 @@ fn draw_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
 // Presets Tab
 // ─────────────────────────────────────────────────────────────────────────────
 fn draw_presets_tab(f: &mut Frame, app: &App, area: Rect) {
-    let chunks = Layout::default()
+    // Each slot gets a fixed-height card: name row (3) + actions row (3) = 6 lines each.
+    let slot_constraints: Vec<Constraint> = (0..4).map(|_| Constraint::Length(7)).collect();
+    let rows = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(9), // explanation banner (7 lines + 2 borders)
-            Constraint::Min(0),    // slot placeholders
-        ])
+        .constraints(slot_constraints)
         .margin(1)
         .split(area);
 
-    // ── Explanation banner ────────────────────────────────────────────────────
-    let banner = Paragraph::new(vec![
+    for i in 0..4 {
+        draw_preset_card(f, app, i, rows[i]);
+    }
+}
+
+fn draw_preset_card(f: &mut Frame, app: &App, index: usize, area: Rect) {
+    // Split the card into name row and actions row.
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Length(4)])
+        .split(area);
+
+    draw_preset_name_row(f, app, index, rows[0]);
+    draw_preset_actions_row(f, app, index, rows[1]);
+}
+
+fn draw_preset_name_row(f: &mut Frame, app: &App, index: usize, area: Rect) {
+    let focused = app.focus == Focus::PresetName(index);
+    let editing = app.editing_preset_name && app.editing_preset_index == index;
+
+    let (name_text, border_color, title_style) = match &app.presets[index] {
+        Some(slot) => {
+            let display = if editing {
+                format!("{}_", slot.name) // show cursor
+            } else {
+                slot.name.clone()
+            };
+            let color = if editing {
+                C_ACCENT
+            } else if focused {
+                C_FOCUS
+            } else {
+                C_BORDER
+            };
+            let style = if focused || editing {
+                Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(C_TEXT)
+            };
+            (display, color, style)
+        }
+        None => {
+            let color = if focused { C_FOCUS } else { C_DISABLED };
+            let style = if focused {
+                Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(C_DISABLED)
+            };
+            (String::from("Empty"), color, style)
+        }
+    };
+
+    let hint = if editing {
+        Span::styled("  [Enter/Esc] confirm", Style::default().fg(C_ACCENT))
+    } else if focused && app.presets[index].is_some() {
+        Span::styled("  [Enter] rename", Style::default().fg(C_DIM))
+    } else {
+        Span::raw("")
+    };
+
+    let summary_line = match &app.presets[index] {
+        Some(slot) if !editing => {
+            Line::from(Span::styled(slot.summary(), Style::default().fg(C_DIM)))
+        }
+        _ => Line::from(""),
+    };
+
+    let content = vec![
         Line::from(vec![
             Span::styled(
-                "⚠  ",
-                Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
+                format!("  {name_text}"),
+                if editing {
+                    Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(C_TEXT)
+                },
             ),
-            Span::styled(
-                "Preset save/recall is not yet implemented.",
-                Style::default().fg(C_TEXT).add_modifier(Modifier::BOLD),
-            ),
+            hint,
         ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "The MVX2U hardware supports 4 on-device preset slots, but the USB HID",
-            Style::default().fg(C_DIM),
-        )),
-        Line::from(Span::styled(
-            "commands for save/recall have not been reverse-engineered yet.",
-            Style::default().fg(C_DIM),
-        )),
-        Line::from(""),
-        Line::from(Span::styled(
-            "To help: capture packets with usbmon while using MOTIV Desktop on",
-            Style::default().fg(C_DIM),
-        )),
-        Line::from(Span::styled(
-            "Windows/Mac, then open an issue at the project repository.",
-            Style::default().fg(C_DIM),
-        )),
-    ])
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(C_WARN))
-            .padding(Padding::horizontal(1)),
-    );
-    f.render_widget(banner, chunks[0]);
+        summary_line,
+    ];
 
-    // ── Slot placeholders ─────────────────────────────────────────────────────
-    let slot_rows = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints(vec![Constraint::Length(3); 4])
-        .split(chunks[1]);
-
-    let show_count = slot_rows.len().min(4);
-    for i in 0..show_count {
-        let foc = app.focus == Focus::PresetSlot(i);
-        let placeholder = Paragraph::new(Line::from(Span::styled(
-            "not implemented",
-            Style::default().fg(C_DISABLED),
-        )))
+    let block = Paragraph::new(content)
         .block(
             Block::default()
                 .title(Span::styled(
-                    format!("  Preset {}  ", i + 1),
-                    if foc {
-                        Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(C_DIM)
-                    },
+                    format!("  Preset {}  ", index + 1),
+                    title_style,
                 ))
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(if foc {
-                    Style::default().fg(C_FOCUS)
+                .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+                .border_type(if focused || editing {
+                    BorderType::Thick
                 } else {
-                    Style::default().fg(C_DISABLED)
+                    BorderType::Rounded
                 })
+                .border_style(Style::default().fg(border_color))
                 .padding(Padding::horizontal(1)),
-        );
-        f.render_widget(placeholder, slot_rows[i]);
-    }
+        )
+        .style(Style::default().bg(C_BG));
+    f.render_widget(block, area);
+}
+
+fn draw_preset_actions_row(f: &mut Frame, app: &App, index: usize, area: Rect) {
+    let focused = app.focus == Focus::PresetActions(index);
+    let filled = app.presets[index].is_some();
+
+    let actions: Line = if filled {
+        Line::from(vec![
+            Span::styled(
+                " [Enter] ",
+                Style::default()
+                    .fg(if focused { C_ACCENT } else { C_DIM })
+                    .add_modifier(if focused {
+                        Modifier::BOLD
+                    } else {
+                        Modifier::empty()
+                    }),
+            ),
+            Span::styled(
+                "Load  ",
+                Style::default().fg(if focused { C_TEXT } else { C_DIM }),
+            ),
+            Span::styled(
+                " [s] ",
+                Style::default().fg(if focused { C_ACCENT } else { C_DIM }),
+            ),
+            Span::styled(
+                "Save  ",
+                Style::default().fg(if focused { C_TEXT } else { C_DIM }),
+            ),
+            Span::styled(
+                " [d] ",
+                Style::default().fg(if focused { C_ERROR } else { C_DIM }),
+            ),
+            Span::styled(
+                "Delete",
+                Style::default().fg(if focused { C_TEXT } else { C_DIM }),
+            ),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(
+                " [s] ",
+                Style::default().fg(if focused { C_ACCENT } else { C_DIM }),
+            ),
+            Span::styled(
+                "Save current settings here",
+                Style::default().fg(if focused { C_TEXT } else { C_DISABLED }),
+            ),
+        ])
+    };
+
+    let border_color = if focused { C_FOCUS } else { C_BORDER };
+
+    let block = Paragraph::new(vec![Line::from(""), actions])
+        .block(
+            Block::default()
+                .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
+                .border_type(if focused {
+                    BorderType::Thick
+                } else {
+                    BorderType::Rounded
+                })
+                .border_style(Style::default().fg(border_color))
+                .padding(Padding::horizontal(1)),
+        )
+        .style(Style::default().bg(C_BG));
+    f.render_widget(block, area);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1399,10 +1495,6 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
         Line::from(vec![
             Span::styled("  Serial No.   : ", Style::default().fg(C_DIM)),
             Span::styled(&*ds.serial_number, Style::default().fg(C_TEXT)),
-        ]),
-        Line::from(vec![
-            Span::styled("  Firmware     : ", Style::default().fg(C_DIM)),
-            Span::styled(&*ds.firmware_version, Style::default().fg(C_TEXT)),
         ]),
         Line::from(vec![
             Span::styled("  USB VID/PID  : ", Style::default().fg(C_DIM)),
@@ -1436,7 +1528,7 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("  Presets      : ", Style::default().fg(C_DIM)),
-            Span::styled("4 slots (stored on device)", Style::default().fg(C_TEXT)),
+            Span::styled("4 slots", Style::default().fg(C_TEXT)),
         ]),
         Line::from(""),
         Line::from(Span::styled(
@@ -1470,7 +1562,7 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
 // ─────────────────────────────────────────────────────────────────────────────
 fn draw_help_overlay(f: &mut Frame, area: Rect) {
     let popup_width = 58u16.min(area.width.saturating_sub(4));
-    let popup_height = 22u16.min(area.height.saturating_sub(4));
+    let popup_height = 32u16.min(area.height.saturating_sub(4));
     let x = (area.width.saturating_sub(popup_width)) / 2;
     let y = (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(x, y, popup_width, popup_height);
@@ -1538,6 +1630,29 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled("  q / Ctrl+C       ", Style::default().fg(C_ACCENT)),
             Span::styled("Quit", Style::default().fg(C_DIM)),
+        ]),
+        Line::from(""),
+        Line::from(vec![Span::styled(
+            "  Presets tab",
+            Style::default()
+                .fg(C_TEXT)
+                .add_modifier(Modifier::UNDERLINED),
+        )]),
+        Line::from(vec![
+            Span::styled("  Enter (on name)  ", Style::default().fg(C_ACCENT)),
+            Span::styled("Rename preset", Style::default().fg(C_DIM)),
+        ]),
+        Line::from(vec![
+            Span::styled("  Enter (on actions)", Style::default().fg(C_ACCENT)),
+            Span::styled("Load preset to device", Style::default().fg(C_DIM)),
+        ]),
+        Line::from(vec![
+            Span::styled("  s                ", Style::default().fg(C_ACCENT)),
+            Span::styled("Save current settings to slot", Style::default().fg(C_DIM)),
+        ]),
+        Line::from(vec![
+            Span::styled("  d / Delete       ", Style::default().fg(C_ACCENT)),
+            Span::styled("Delete preset", Style::default().fg(C_DIM)),
         ]),
         Line::from(""),
         Line::from(Span::styled(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9,7 +9,9 @@ use ratatui::{
 };
 
 use crate::app::{App, Focus, Tab};
-use crate::protocol::{AutoGain, AutoTone, EQ_BAND_FREQS, InputMode, MicPosition};
+use crate::protocol::{
+    AutoGain, AutoTone, CompressorPreset, EQ_BAND_FREQS, HpfFrequency, InputMode, MicPosition,
+};
 
 // ── Palette ───────────────────────────────────────────────────────────────────
 const C_ACCENT: Color = Color::Rgb(255, 95, 0); // Shure orange
@@ -495,6 +497,11 @@ fn draw_mute_block(f: &mut Frame, app: &App, area: Rect) {
 ///
 /// `rows` must have at least 4 elements (indices 0–3).
 fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
+    debug_assert!(
+        rows.len() >= 4,
+        "draw_main_shared requires at least 4 row slots, got {}",
+        rows.len()
+    );
     // ── Level Meter ───────────────────────────────────────────────────────────
     draw_meter(f, app, rows[0]);
 
@@ -654,7 +661,7 @@ fn draw_main_right(f: &mut Frame, app: &App, area: Rect) {
             if ds.muted {
                 Span::styled("YES", Style::default().fg(C_ERROR))
             } else {
-                Span::styled("No", Style::default().fg(C_SUCCESS))
+                Span::styled("NO", Style::default().fg(C_SUCCESS))
             },
         ]),
         Line::from(vec![
@@ -662,7 +669,7 @@ fn draw_main_right(f: &mut Frame, app: &App, area: Rect) {
             if ds.locked {
                 Span::styled("YES", Style::default().fg(C_ERROR))
             } else {
-                Span::styled("No", Style::default().fg(C_DIM))
+                Span::styled("NO", Style::default().fg(C_DIM))
             },
         ]),
         Line::from(vec![
@@ -670,7 +677,7 @@ fn draw_main_right(f: &mut Frame, app: &App, area: Rect) {
             if ds.phantom_power {
                 Span::styled("48V ON", Style::default().fg(C_SUCCESS))
             } else {
-                Span::styled("Off", Style::default().fg(C_DIM))
+                Span::styled("OFF", Style::default().fg(C_DIM))
             },
         ]),
         Line::from(""),
@@ -699,7 +706,7 @@ fn draw_main_right(f: &mut Frame, app: &App, area: Rect) {
             } else if ds.limiter_enabled {
                 Span::styled("ON", Style::default().fg(C_SUCCESS))
             } else {
-                Span::styled("Off", Style::default().fg(C_DIM))
+                Span::styled("OFF", Style::default().fg(C_DIM))
             },
         ]),
         Line::from(vec![
@@ -1184,27 +1191,31 @@ fn draw_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
 
     // ── Compressor ────────────────────────────────────────────────────────────
     let comp_foc = app.focus == Focus::Compressor;
-    let comp_lines: Vec<Line> = ["Off", "Light", "Medium", "Heavy"]
-        .iter()
-        .map(|label| {
-            let selected =
-                label.to_lowercase() == app.device_state.compressor.to_string().to_lowercase();
-            Line::from(vec![
-                Span::styled(
-                    if selected { "▶ " } else { "  " },
-                    Style::default().fg(C_ACCENT),
-                ),
-                Span::styled(
-                    *label,
-                    if selected {
-                        Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(C_DIM)
-                    },
-                ),
-            ])
-        })
-        .collect();
+    let comp_lines: Vec<Line> = [
+        CompressorPreset::Off,
+        CompressorPreset::Light,
+        CompressorPreset::Medium,
+        CompressorPreset::Heavy,
+    ]
+    .iter()
+    .map(|preset| {
+        let selected = *preset == app.device_state.compressor;
+        Line::from(vec![
+            Span::styled(
+                if selected { "▶ " } else { "  " },
+                Style::default().fg(C_ACCENT),
+            ),
+            Span::styled(
+                preset.to_string(),
+                if selected {
+                    Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(C_DIM)
+                },
+            ),
+        ])
+    })
+    .collect();
 
     let mut comp_content = vec![Line::from("")];
     comp_content.extend(comp_lines);
@@ -1237,17 +1248,17 @@ fn draw_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
 
     // ── HPF ───────────────────────────────────────────────────────────────────
     let hpf_foc = app.focus == Focus::Hpf;
-    let hpf_lines: Vec<Line> = ["Off", "75 Hz", "150 Hz"]
+    let hpf_lines: Vec<Line> = [HpfFrequency::Off, HpfFrequency::Hz75, HpfFrequency::Hz150]
         .iter()
-        .map(|label| {
-            let selected = *label == app.device_state.hpf.to_string();
+        .map(|freq| {
+            let selected = *freq == app.device_state.hpf;
             Line::from(vec![
                 Span::styled(
                     if selected { "▶ " } else { "  " },
                     Style::default().fg(C_ACCENT),
                 ),
                 Span::styled(
-                    *label,
+                    freq.to_string(),
                     if selected {
                         Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
                     } else {


### PR DESCRIPTION
feat: add host-side preset manager (Presets tab, v1.1.0)
Implement 4 named preset slots stored as TOML files in
~/.config/shurectl/presets/. Mirrors how MOTIV Desktop handles
presets: the app sends a full batch of SET commands on load with
no device-side preset bank involved.

presets.rs: new module — PresetSlot (serde), save/load/delete/
  load_all_presets(), serialisable mirror types for all protocol enums
app.rs: replace PresetSlot focus with PresetName/PresetActions per
  slot; add editing_preset_name state; add SavePreset, LoadPreset,
  DeletePreset, PersistPresetName DeviceAction variants; fix focus
  cycle order to match screen layout; reset focus to Gain on Main
  tab in Manual mode
main.rs: load presets at startup; handle name editing keys (printable
  chars, Backspace, Enter/Esc); s/d/Delete bindings on Presets tab;
  apply_preset_to_device sends full state batch on load
ui.rs: rewrite draw_presets_tab with name row + actions row per slot;
  mode-aware summary line (Auto omits EQ/dynamics fields); status bar
  shows editing hint; help overlay updated; f.size() -> f.area()
protocol.rs: remove firmware_version from DeviceState — field was
  never populated and always displayed "Unknown"
Cargo.toml: add serde, toml, dirs-next, tempfile (dev)
README.md: add presets.rs to architecture; expand features list;
  add Presets section; add s/d keybinding rows; bump min Rust to 1.85
CLAUDE.md: update project structure, domain rules, crate versions
minor formatting nits