### PR TITLE
Uaccess

### DIFF
--- a/60-mvx2u.rules
+++ b/60-mvx2u.rules
@@ -1,6 +1,6 @@
 # Shure MVX2U Digital Audio Interface
 # Grants access to /dev/hidrawN to the currently logged-in user via uaccess.
 # No group membership required.
-# Install to: /etc/udev/rules.d/99-mvx2u.rules
+# Install to: /etc/udev/rules.d/60-mvx2u.rules
 # Then run: sudo udevadm control --reload-rules && sudo udevadm trigger
 ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"

--- a/62-mvx2u.rules
+++ b/62-mvx2u.rules
@@ -1,6 +1,6 @@
 # Shure MVX2U Digital Audio Interface
 # Grants access to /dev/hidrawN to the currently logged-in user via uaccess.
 # No group membership required.
-# Install to: /etc/udev/rules.d/60-mvx2u.rules
+# Install to: /etc/udev/rules.d/62-mvx2u.rules
 # Then run: sudo udevadm control --reload-rules && sudo udevadm trigger
 ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Settings persist on the device after disconnect (no host software needed after c
 
 Without a udev rule, `/dev/hidrawN` for the MVX2U is only accessible by root.
 
-Create `/etc/udev/rules.d/60-mvx2u.rules`:
+Create `/etc/udev/rules.d/62-mvx2u.rules`:
 
 ```
 ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Settings persist on the device after disconnect (no host software needed after c
 
 Without a udev rule, `/dev/hidrawN` for the MVX2U is only accessible by root.
 
-Create `/etc/udev/rules.d/99-mvx2u.rules`:
+Create `/etc/udev/rules.d/60-mvx2u.rules`:
 
 ```
 ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"


### PR DESCRIPTION
udev: rename rule file from 99-mvx2u.rules to 62-mvx2u.rules

60-69 is the conventional range for user-defined hardware access rules,
and ensures processing before 73-seat-late.rules as required for uaccess
tagging to take effect.