### PR TITLE
Update Unit Tests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1010,6 +1010,53 @@ mod tests {
     }
 
     #[test]
+    fn toggle_phantom_flips_state_and_returns_action() {
+        let mut app = App::default();
+        app.focus = Focus::Phantom;
+        app.device_state.phantom_power = false;
+
+        let action = app.toggle_focused();
+        assert!(app.device_state.phantom_power);
+        assert!(matches!(action, Some(DeviceAction::SetPhantom(true))));
+
+        let action = app.toggle_focused();
+        assert!(!app.device_state.phantom_power);
+        assert!(matches!(action, Some(DeviceAction::SetPhantom(false))));
+    }
+
+    #[test]
+    fn toggle_eq_enable_flips_state_and_returns_action() {
+        let mut app = App::default();
+        app.active_tab = Tab::Eq;
+        app.focus = Focus::EqEnable;
+        app.device_state.eq_enabled = false;
+
+        let action = app.toggle_focused();
+        assert!(app.device_state.eq_enabled);
+        assert!(matches!(action, Some(DeviceAction::SetEqEnable(true))));
+
+        let action = app.toggle_focused();
+        assert!(!app.device_state.eq_enabled);
+        assert!(matches!(action, Some(DeviceAction::SetEqEnable(false))));
+    }
+
+    #[test]
+    fn toggle_limiter_flips_state_and_returns_action() {
+        let mut app = App::default();
+        app.active_tab = Tab::Dynamics;
+        app.focus = Focus::Limiter;
+        app.device_state.limiter_enabled = false;
+
+        let action = app.toggle_focused();
+        assert!(app.device_state.limiter_enabled);
+        assert!(matches!(action, Some(DeviceAction::SetLimiter(true))));
+
+        let action = app.toggle_focused();
+        assert!(!app.device_state.limiter_enabled);
+        assert!(matches!(action, Some(DeviceAction::SetLimiter(false))));
+    }
+
+    #[test]
     fn toggle_non_toggleable_focus_returns_none() {
         let mut app = App::default();
         for focus in [

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1069,6 +1069,26 @@ mod tests {
     }
 
     #[test]
+    fn set_limiter_encodes_on_off() {
+        let pkt = cmd_set_limiter(0, true);
+        assert_eq!(&pkt[14..16], &FEAT_LIMITER);
+        assert_eq!(pkt[16], 1, "limiter enabled must encode as 1");
+
+        let pkt = cmd_set_limiter(0, false);
+        assert_eq!(pkt[16], 0, "limiter disabled must encode as 0");
+    }
+
+    #[test]
+    fn set_eq_enable_encodes_on_off() {
+        let pkt = cmd_set_eq_enable(0, true);
+        assert_eq!(&pkt[14..16], &FEAT_EQ);
+        assert_eq!(pkt[16], 1, "EQ enabled must encode as 1");
+
+        let pkt = cmd_set_eq_enable(0, false);
+        assert_eq!(pkt[16], 0, "EQ disabled must encode as 0");
+    }
+
+    #[test]
     fn set_mode_encodes_auto_manual() {
         assert_eq!(cmd_set_mode(0, true)[16], 1, "auto=true must be 1");
         assert_eq!(cmd_set_mode(0, false)[16], 0, "auto=false must be 0");


### PR DESCRIPTION
Add missing toggle_focused tests for Phantom, EqEnable, and Limiter. This gets us to 150 total unit tests. A sensible amount of coverage