### PR TITLE
feat: add -l shorthand for --list and -V/--version flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ use protocol::InputMode;
 #[derive(Parser)]
 #[command(
     name = "shurectl",
+    version,
     about = "shurectl — TUI configurator for the Shure MVX2U audio interface"
 )]
 struct Cli {
@@ -46,7 +47,7 @@ struct Cli {
     demo: bool,
 
     /// List connected MVX2U devices and exit
-    #[arg(long)]
+    #[arg(long, short)]
     list: bool,
 }
 


### PR DESCRIPTION
clap's version attribute pulls the version from Cargo.toml at compile time. -V is used instead of -v to follow clap convention and keep -v free for a potential future --verbose flag.