### PR TITLE
Add macOS support via platform-conditional hidapi deps

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,15 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            sys-deps: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev
+          - os: macos-latest
+            sys-deps: ""
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
@@ -21,7 +29,8 @@ jobs:
         persist-credentials: false
 
     - name: Install system dependencies
-      run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev
+      if: matrix.sys-deps != ''
+      run: ${{ matrix.sys-deps }}
 
     - name: Build
       run: cargo build --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shurectl"
 version = "1.3.0"
 edition = "2024"
-description = "shurectl — TUI configurator for the Shure MVX2U audio interface on Linux"
+description = "shurectl — TUI configurator for the Shure MVX2U audio interface"
 
 [[bin]]
 name = "shurectl"
@@ -11,7 +11,6 @@ path = "src/main.rs"
 [dependencies]
 ratatui = "0.30"
 crossterm = "0.29"
-hidapi = { version = "2.4.1", default-features = false, features = ["linux-native"] }
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 cpal = "0.17"
@@ -19,6 +18,12 @@ libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 dirs-next = "2.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+hidapi = { version = "2.4.1", default-features = false, features = ["linux-native"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+hidapi = { version = "2.4.1", default-features = false, features = ["macos-shared-device"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # shurectl
 
 An open-source terminal UI configurator for the **Shure MVX2U** XLR-to-USB audio
-interface on Linux. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
+interface on Linux and macOS. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
 
 ![Project Example Screenshot](images/shurectl.png)
 
@@ -28,7 +28,9 @@ Settings persist on the device after disconnect (no host software needed after c
 
 ---
 
-## udev Rule (Required for Non-Root Access)
+## Platform Setup
+
+### Linux — udev Rule (Required for Non-Root Access)
 
 Without a udev rule, `/dev/hidrawN` for the MVX2U is only accessible by root.
 
@@ -56,6 +58,11 @@ shurectl --list
 #   /dev/hidraw3 | S/N: MVX2U#3-7d84d19...
 #   /dev/hidraw2 | S/N: MVX2U#3-17b7a6c...
 ```
+
+### macOS — No Extra Setup Required
+
+On macOS, IOKit grants user-space access to HID devices without extra configuration.
+Plug in the MVX2U and run `shurectl --list` to confirm detection.
 
 ---
 
@@ -94,10 +101,10 @@ cargo install --git https://github.com/Humblemonk/shurectl.git
 ## Usage
 
 ```bash
-shurectl                        # Connect to first detected device and launch TUI
-shurectl --device /dev/hidraw3  # Connect to a specific device (use --list to find paths)
-shurectl --demo                 # Run without a device (explore the UI)
-shurectl --list                 # List detected MVX2U devices and exit
+shurectl                         # Connect to first detected device and launch TUI
+shurectl --device <path>         # Connect to a specific device (use --list to find paths)
+shurectl --demo                  # Run without a device (explore the UI)
+shurectl --list                  # List detected MVX2U devices and exit
 ```
 
 ### Keyboard Shortcuts
@@ -161,8 +168,8 @@ All command byte values, feature addresses, and packet structure details are doc
 
 ## Troubleshooting
 
-**"Cannot open MVX2U"** — udev rule not installed, or device not plugged in.
-Run `shurectl --list` to check detection. Try `sudo shurectl` to confirm it's a permissions issue.
+**"Cannot open MVX2U"** — device not found or a permissions issue.
+Run `shurectl --list` to check detection. On Linux, try `sudo shurectl` to confirm it's a udev permissions issue. On macOS, ensure no other software has exclusive access to the device.
 
 **Gain slider is greyed out in Auto Level mode** — This is correct hardware behaviour;
 the device ignores gain commands in Auto Level mode. Switch to Manual mode first.

--- a/src/device.rs
+++ b/src/device.rs
@@ -5,9 +5,11 @@
 //!   Interface 1 – USB Audio streaming
 //!   Interface 2 – HID configuration (the one we need)
 //!
-//! hidapi on Linux will open the HID interface by matching VID/PID.
-//! Because snd-usb-audio also claims the device, hidapi uses /dev/hidrawN
-//! which bypasses the audio driver entirely — no kernel detach needed.
+//! hidapi opens the HID configuration interface (interface 2) by matching VID/PID.
+//! On Linux, snd-usb-audio claims the audio interfaces, but hidapi uses /dev/hidrawN
+//! for the HID interface, bypassing the audio driver entirely — no kernel detach needed.
+//! On macOS, IOHidManager opens the HID interface alongside CoreAudio; the
+//! `macos-shared-device` hidapi feature enables non-exclusive access for this.
 //!
 //! # Transport
 //!
@@ -28,6 +30,11 @@
 use std::sync::atomic::{AtomicU8, Ordering};
 
 use anyhow::{Context, Result, anyhow};
+
+#[cfg(target_os = "linux")]
+const ACCESS_HINT: &str = "ensure the udev rule is installed, or run with sudo";
+#[cfg(not(target_os = "linux"))]
+const ACCESS_HINT: &str = "ensure the device is plugged in and accessible";
 use hidapi::{HidApi, HidDevice};
 
 use crate::protocol::{
@@ -74,7 +81,7 @@ impl Mvx2u {
         let device = api.open(VID, PID).map_err(|e| {
             anyhow!(
                 "Cannot open MVX2U (VID={:#06x} PID={:#06x}): {e}\n\
-                Hint: ensure the udev rule is installed or run with sudo.",
+                Hint: {ACCESS_HINT}.",
                 VID,
                 PID
             )
@@ -82,7 +89,7 @@ impl Mvx2u {
         Ok(Self::from_hid_device(device))
     }
 
-    /// Open the MVX2U at a specific hidraw path (e.g. `/dev/hidraw3`).
+    /// Open the MVX2U at a specific HID device path (use `--list` to find paths).
     ///
     /// Returns an error if the path is not found in the device list or does
     /// not identify a Shure MVX2U (VID/PID mismatch).
@@ -111,11 +118,9 @@ impl Mvx2u {
         // VID/PID, so any remaining error here is a permissions problem.
         let c_path = std::ffi::CString::new(path)
             .map_err(|_| anyhow!("Device path contains a null byte: {path}"))?;
-        let device = api.open_path(c_path.as_c_str()).map_err(|e| {
-            anyhow!(
-                "Cannot open {path}: {e}\nHint: ensure the udev rule is installed or run with sudo."
-            )
-        })?;
+        let device = api
+            .open_path(c_path.as_c_str())
+            .map_err(|e| anyhow!("Cannot open {path}: {e}\nHint: {ACCESS_HINT}."))?;
         Ok(Self::from_hid_device(device))
     }
 
@@ -321,7 +326,7 @@ impl Mvx2u {
 
 /// Information about a detected MVX2U, returned by [`list_devices`].
 pub struct DeviceInfo {
-    /// Path to the hidraw node, e.g. `/dev/hidraw3`.
+    /// Platform-specific HID device path (e.g. `/dev/hidraw3` on Linux).
     pub path: String,
     /// USB serial number string, e.g. `MVX2U#3-7d84d19...`.
     pub serial: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
-//! shurectl — Interactive TUI configurator for the Shure MVX2U on Linux
+//! shurectl — Interactive TUI configurator for the Shure MVX2U
 //!
 //! Usage:
-//!   shure               # Connect to device, launch TUI
-//!   shure --demo        # Run without a device (for testing)
-//!   shure --list        # List detected devices and exit
+//!   shurectl               # Connect to device, launch TUI
+//!   shurectl --demo        # Run without a device (for testing)
+//!   shurectl --list        # List detected devices and exit
 //!
-//! See README.md for udev setup and permissions.
+//! See README.md for platform-specific setup and permissions.
 
 mod app;
 mod device;
@@ -50,7 +50,7 @@ struct Cli {
     #[arg(long, short)]
     list: bool,
 
-    /// Open a specific device by hidraw path (e.g. /dev/hidraw3).
+    /// Open a specific device by its HID path.
     /// Without this flag, the first detected MVX2U is opened.
     /// Use --list to see available paths.
     #[arg(long, short = 'D')]
@@ -64,7 +64,10 @@ fn main() -> Result<()> {
         let devs = device::list_devices();
         if devs.is_empty() {
             println!("No Shure MVX2U devices found.");
+            #[cfg(target_os = "linux")]
             println!("Check that the device is plugged in and the udev rule is installed.");
+            #[cfg(not(target_os = "linux"))]
+            println!("Check that the device is plugged in and accessible.");
         } else {
             println!("Found {} MVX2U device(s):", devs.len());
             for d in devs {


### PR DESCRIPTION
Quick port to macOS with support from Claude Code. Uses `cfg` checks to detect platform and swap in the `macos-shared-device` `hidapi` backend if it's being built on macOS. No other functional changes were required, but made minor updates to help messages and readme along with CI config.