### PR TITLE
 feat: add Shure MV6 support (v2.0.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ Suggesting improvements:
 - Validate all packet arguments before encoding (clamp ranges, not panic)
 - No secrets in source — if a config file is added, use environment variables or `~/.config/`
 - Never write firmware update packets — the firmware update byte sequences are intentionally
-  omitted from this codebase (see README legal section)
+  omitted from this codebase (see readme legal section)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
 # shurectl — Project Instructions
 
 The goal of this project is to build and maintain **shurectl**, an open-source terminal UI
-configurator for the Shure MVX2U XLR-to-USB audio interface on Linux. It replaces the
-Windows/Mac-only ShurePlus MOTIV Desktop app by communicating with the device directly over
-USB HID.
+configurator for Shure USB audio interfaces (currently the **MVX2U** and **MV6**) on Linux
+and macOS. It replaces the Windows/Mac-only ShurePlus MOTIV Desktop app by communicating
+with devices directly over USB HID.
 
 This is a Rust project. Operate as a senior Rust developer: write clean, readable, maintainable
 code. Avoid clever abstractions. The simple, obvious solution is almost always correct.
@@ -302,7 +302,7 @@ Suggesting improvements:
 - Validate all packet arguments before encoding (clamp ranges, not panic)
 - No secrets in source — if a config file is added, use environment variables or `~/.config/`
 - Never write firmware update packets — the firmware update byte sequences are intentionally
-  omitted from this codebase (see readme legal section)
+  omitted from this codebase (see README legal section)
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
 ]
@@ -139,9 +139,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -301,7 +301,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16dd574a72a021b90c7656c474ea31d11a2f0366a8eff574186e761e0b9e3586"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -354,7 +354,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -509,7 +509,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filedescriptor"
@@ -707,6 +707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,12 +759,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -863,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -904,15 +910,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -933,7 +939,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -965,9 +971,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -1036,7 +1042,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -1065,7 +1071,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1078,7 +1084,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1166,7 +1172,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "objc2",
  "objc2-core-audio",
@@ -1204,7 +1210,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
@@ -1214,7 +1220,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2",
  "dispatch2",
  "libc",
@@ -1233,7 +1239,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -1387,9 +1393,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1419,7 +1425,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -1487,7 +1493,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -1539,7 +1545,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -1558,7 +1564,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1616,7 +1622,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1652,9 +1658,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1727,7 +1733,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shurectl"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1888,7 +1894,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -2029,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -2182,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2195,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2205,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2215,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2228,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -2263,7 +2269,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2271,9 +2277,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2709,7 +2715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shurectl"
-version = "1.3.1"
+version = "2.0.0"
 edition = "2024"
 description = "shurectl — TUI configurator for the Shure MVX2U audio interface"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # shurectl
 
 An open-source terminal UI configurator for the **Shure MVX2U** XLR-to-USB audio
-interface on Linux and macOS. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
+interface and **Shure MV6** microphone on Linux and macOS. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
 
 ![Project Example Screenshot](images/shurectl.png)
 
@@ -32,13 +32,19 @@ Settings persist on the device after disconnect (no host software needed after c
 
 ### Linux — udev Rule (Required for Non-Root Access)
 
-Without a udev rule, `/dev/hidrawN` for the MVX2U is only accessible by root.
+Without a udev rule, `/dev/hidrawN` for the device is only accessible by root.
 
 Create `/etc/udev/rules.d/62-mvx2u.rules`:
 
 ```
 ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"
 ```
+Create `/etc/udev/rules.d/62-mv6.rules`:
+
+```
+ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1026", TAG+="uaccess"
+```
+
 Then reload udev and replug your device:
 
 ```bash
@@ -62,7 +68,7 @@ shurectl --list
 ### macOS — No Extra Setup Required
 
 On macOS, IOKit grants user-space access to HID devices without extra configuration.
-Plug in the MVX2U and run `shurectl --list` to confirm detection.
+Plug in your device and run `shurectl --list` to confirm detection.
 
 ---
 
@@ -104,7 +110,7 @@ cargo install --git https://github.com/Humblemonk/shurectl.git
 shurectl                         # Connect to first detected device and launch TUI
 shurectl --device <path>         # Connect to a specific device (use --list to find paths)
 shurectl --demo                  # Run without a device (explore the UI)
-shurectl --list                  # List detected MVX2U devices and exit
+shurectl --list                  # List detected Shure devices and exit
 ```
 
 ### Keyboard Shortcuts
@@ -155,7 +161,7 @@ On the **Presets tab**:
 src/
 ├── main.rs       — Entry point, event loop, CLI args
 ├── app.rs        — Application state, focus/tab navigation, DeviceAction events
-├── device.rs     — hidapi wrapper; open/send/receive for MVX2U
+├── device.rs     — hidapi wrapper; open/send/receive for Shure devices
 ├── meter.rs      — cpal audio capture; real-time dBFS metering, RollingWindow, PeakWindow
 ├── presets.rs    — Host-side preset storage: TOML serialisation, load/save/delete, PresetSlot
 ├── protocol.rs   — USB HID packet encoding, CRC-16/ANSI, command constructors, apply_response()
@@ -168,14 +174,14 @@ All command byte values, feature addresses, and packet structure details are doc
 
 ## Troubleshooting
 
-**"Cannot open MVX2U"** — device not found or a permissions issue.
+**"Cannot open device"** — device not found or a permissions issue.
 Run `shurectl --list` to check detection. On Linux, try `sudo shurectl` to confirm it's a udev permissions issue. On macOS, ensure no other software has exclusive access to the device.
 
 **Gain slider is greyed out in Auto Level mode** — This is correct hardware behaviour;
 the device ignores gain commands in Auto Level mode. Switch to Manual mode first.
 
 **PipeWire/PulseAudio volume vs. device gain** — This tool controls the **hardware DSP gain**
-on the MVX2U itself, not the OS capture volume level. Both can be set independently.
+on the device itself, not the OS capture volume level. Both can be set independently.
 
 ---
 
@@ -195,7 +201,7 @@ issues during implementation. All code was reviewed and tested by the author bef
 ## Legal
 
 Protocol implementation is based on publicly documented USB HID packet captures
-by PennRobotics (shux project, Apache 2.0). No Shure software was used, decompiled,
+by PennRobotics (shux project, Apache 2.0) as well as author's own usbmon captures. No Shure software was used, decompiled,
 or examined in the creation of this tool.
 
 shurectl is not affiliated with or endorsed by Shure Incorporated.

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,8 @@ use std::sync::{Arc, Mutex};
 use crate::meter::{METER_SILENT, PeakWindow};
 use crate::presets::{PRESET_COUNT, PresetSlot};
 use crate::protocol::{
-    AutoGain, AutoTone, CompressorPreset, DeviceState, HpfFrequency, InputMode, MicPosition,
+    AutoGain, AutoTone, CompressorPreset, DeviceModel, DeviceState, HpfFrequency, InputMode,
+    MicPosition,
 };
 
 /// Which top-level tab/panel is active.
@@ -68,15 +69,23 @@ pub enum Focus {
     AutoPosition,
     AutoTone,
     AutoGain,
-    // EQ tab — focus carries the band index (0–4)
+    // EQ tab — MVX2U bands
     EqEnable,
     EqBandSelect,
     EqBandEnable(usize),
     EqGain(usize),
-    // Dynamics tab
+    // EQ tab — MV6 tone
+    Tone,
+    // Dynamics tab — MVX2U
     Limiter,
     Compressor,
     Hpf,
+    // Dynamics tab — MV6 extra controls
+    Denoiser,
+    PopperStopper,
+    MuteBtnDisable,
+    // Main tab — MV6 gain lock (Manual mode only)
+    GainLock,
     // Presets tab — usize is slot index 0–3
     PresetName(usize),
     PresetActions(usize),
@@ -95,6 +104,8 @@ pub struct App {
     pub should_quit: bool,
     pub demo_mode: bool,
     pub help_visible: bool,
+    /// Which device model is connected. Drives which controls are shown.
+    pub device_model: DeviceModel,
     /// Loaded preset slots. `None` means the slot file does not exist yet.
     pub presets: [Option<PresetSlot>; PRESET_COUNT],
     /// Set to `true` while the user is typing a new name for a preset slot.
@@ -121,6 +132,7 @@ impl Default for App {
             should_quit: false,
             demo_mode: false,
             help_visible: false,
+            device_model: DeviceModel::Mvx2u,
             presets: [None, None, None, None],
             editing_preset_name: false,
             editing_preset_index: 0,
@@ -147,12 +159,13 @@ impl App {
     // ── Tab navigation ────────────────────────────────────────────────────────
 
     /// Returns true when a tab should be inaccessible given the current device state.
-    /// EQ and Dynamics are managed by the device in Auto Level mode and cannot be
-    /// configured independently.
+    ///
+    /// MVX2U: EQ and Dynamics are locked in Auto Level mode (device manages them).
+    /// MV6:   EQ (Tone) and Dynamics are always accessible.
     pub fn is_tab_locked(&self, tab: Tab) -> bool {
         matches!(
-            (tab, self.device_state.mode),
-            (Tab::Eq | Tab::Dynamics, InputMode::Auto)
+            (tab, self.device_model, self.device_state.mode),
+            (Tab::Eq | Tab::Dynamics, DeviceModel::Mvx2u, InputMode::Auto)
         )
     }
 
@@ -183,104 +196,151 @@ impl App {
     }
 
     fn reset_focus_for_tab(&mut self) {
-        self.focus = match self.active_tab {
-            Tab::Main => match self.device_state.mode {
+        self.focus = match (self.active_tab, self.device_model) {
+            (Tab::Main, DeviceModel::Mv6) => match self.device_state.mode {
                 InputMode::Manual => Focus::Gain,
                 InputMode::Auto => Focus::Mode,
             },
-            Tab::Eq => Focus::EqEnable,
-            Tab::Dynamics => Focus::Limiter,
-            Tab::Presets => Focus::PresetName(0),
-            Tab::Info => Focus::None,
+            (Tab::Main, DeviceModel::Mvx2u) => match self.device_state.mode {
+                InputMode::Manual => Focus::Gain,
+                InputMode::Auto => Focus::Mode,
+            },
+            (Tab::Eq, DeviceModel::Mv6) => Focus::Tone,
+            (Tab::Eq, DeviceModel::Mvx2u) => Focus::EqEnable,
+            (Tab::Dynamics, DeviceModel::Mv6) => Focus::Denoiser,
+            (Tab::Dynamics, DeviceModel::Mvx2u) => Focus::Limiter,
+            (Tab::Presets, _) => Focus::PresetName(0),
+            (Tab::Info, _) => Focus::None,
         };
     }
 
     // ── Focus cycling within a tab ────────────────────────────────────────────
     //
-    // Main tab has two distinct cycles depending on input mode.
-    // Order matches top-to-bottom screen layout:
-    //
+    // MVX2U Main cycles:
     //   Manual: Mode → Mute → Gain → MonitorMix → Phantom → Lock → (wrap)
     //   Auto:   Mode → Mute → AutoPosition → AutoTone → AutoGain → MonitorMix → Phantom → Lock → (wrap)
     //
-    // If focus lands on a mode-specific control while the mode doesn't match
-    // (e.g. user toggles mode while focused on Gain), the wildcard arm catches
-    // it and returns to the correct starting focus for the current mode.
+    // MV6 Main cycles (mirrors MVX2U structure, no extra controls):
+    //   Manual: Mode → Mute → Gain → GainLock → (wrap)
+    //   Auto:   Mode → Mute → (wrap)
+    //
+    // MV6 EQ:      Tone (slider only, no bands)
+    // MV6 Dynamics: Denoiser → PopperStopper → MuteBtnDisable → Hpf → (wrap)
     pub fn focus_next(&mut self) {
-        self.focus = match (&self.active_tab, &self.focus, &self.device_state.mode) {
-            // Manual cycle (top → bottom): Mode → Mute → Gain → MonitorMix → Phantom → Lock
-            (Tab::Main, Focus::Mode, InputMode::Manual) => Focus::Mute,
-            (Tab::Main, Focus::Mute, InputMode::Manual) => Focus::Gain,
-            (Tab::Main, Focus::Gain, InputMode::Manual) => Focus::MonitorMix,
-            // Auto cycle (top → bottom): Mode → Mute → AutoPosition → AutoTone → AutoGain → MonitorMix → Phantom → Lock
-            (Tab::Main, Focus::Mode, InputMode::Auto) => Focus::Mute,
-            (Tab::Main, Focus::Mute, InputMode::Auto) => Focus::AutoPosition,
-            (Tab::Main, Focus::AutoPosition, InputMode::Auto) => Focus::AutoTone,
-            (Tab::Main, Focus::AutoTone, InputMode::Auto) => Focus::AutoGain,
-            (Tab::Main, Focus::AutoGain, InputMode::Auto) => Focus::MonitorMix,
-            // Shared tail (both modes)
-            (Tab::Main, Focus::MonitorMix, _) => Focus::Phantom,
-            (Tab::Main, Focus::Phantom, _) => Focus::Lock,
-            (Tab::Main, Focus::Lock, _) => Focus::Mode,
-            // Fallback — wrong-mode focus or unexpected state
-            (Tab::Main, _, InputMode::Manual) => Focus::Mode,
-            (Tab::Main, _, InputMode::Auto) => Focus::Mode,
+        self.focus = match (&self.active_tab, &self.focus, &self.device_model, &self.device_state.mode) {
+            // ── MV6 Main cycle ────────────────────────────────────────────────
+            (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Manual) => Focus::Mute,
+            (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, Focus::Gain, DeviceModel::Mv6, InputMode::Manual) => Focus::GainLock,
+            (Tab::Main, Focus::GainLock, DeviceModel::Mv6, InputMode::Manual) => Focus::Mode,
+            (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, _, DeviceModel::Mv6, _) => Focus::Mode,
 
-            (Tab::Eq, Focus::EqEnable, _) => Focus::EqBandSelect,
-            (Tab::Eq, Focus::EqBandSelect, _) => Focus::EqBandEnable(self.eq_selected_band),
-            (Tab::Eq, Focus::EqBandEnable(b), _) => Focus::EqGain(*b),
-            (Tab::Eq, Focus::EqGain(_), _) => Focus::EqEnable,
-            (Tab::Eq, _, _) => Focus::EqEnable,
+            // ── MVX2U Manual cycle ────────────────────────────────────────────
+            (Tab::Main, Focus::Mode, DeviceModel::Mvx2u, InputMode::Manual) => Focus::Mute,
+            (Tab::Main, Focus::Mute, DeviceModel::Mvx2u, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, Focus::Gain, DeviceModel::Mvx2u, InputMode::Manual) => Focus::MonitorMix,
+            // ── MVX2U Auto cycle ──────────────────────────────────────────────
+            (Tab::Main, Focus::Mode, DeviceModel::Mvx2u, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::Mute, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoPosition,
+            (Tab::Main, Focus::AutoPosition, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoTone,
+            (Tab::Main, Focus::AutoTone, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoGain,
+            (Tab::Main, Focus::AutoGain, DeviceModel::Mvx2u, InputMode::Auto) => Focus::MonitorMix,
+            // ── MVX2U shared tail ─────────────────────────────────────────────
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mvx2u, _) => Focus::Phantom,
+            (Tab::Main, Focus::Phantom, DeviceModel::Mvx2u, _) => Focus::Lock,
+            (Tab::Main, Focus::Lock, DeviceModel::Mvx2u, _) => Focus::Mode,
+            (Tab::Main, _, DeviceModel::Mvx2u, _) => Focus::Mode,
 
-            (Tab::Dynamics, Focus::Limiter, _) => Focus::Compressor,
-            (Tab::Dynamics, Focus::Compressor, _) => Focus::Hpf,
-            (Tab::Dynamics, Focus::Hpf, _) => Focus::Limiter,
-            (Tab::Dynamics, _, _) => Focus::Limiter,
+            // ── MV6 EQ (Tone only) ────────────────────────────────────────────
+            (Tab::Eq, _, DeviceModel::Mv6, _) => Focus::Tone,
 
-            (Tab::Presets, Focus::PresetName(i), _) => Focus::PresetActions(*i),
-            (Tab::Presets, Focus::PresetActions(i), _) => Focus::PresetName((i + 1) % PRESET_COUNT),
-            (Tab::Presets, _, _) => Focus::PresetName(0),
+            // ── MVX2U EQ ──────────────────────────────────────────────────────
+            (Tab::Eq, Focus::EqEnable, DeviceModel::Mvx2u, _) => Focus::EqBandSelect,
+            (Tab::Eq, Focus::EqBandSelect, DeviceModel::Mvx2u, _) => Focus::EqBandEnable(self.eq_selected_band),
+            (Tab::Eq, Focus::EqBandEnable(b), DeviceModel::Mvx2u, _) => Focus::EqGain(*b),
+            (Tab::Eq, Focus::EqGain(_), DeviceModel::Mvx2u, _) => Focus::EqEnable,
+            (Tab::Eq, _, DeviceModel::Mvx2u, _) => Focus::EqEnable,
+
+            // ── MV6 Dynamics ──────────────────────────────────────────────────
+            (Tab::Dynamics, Focus::Denoiser, DeviceModel::Mv6, _) => Focus::PopperStopper,
+            (Tab::Dynamics, Focus::PopperStopper, DeviceModel::Mv6, _) => Focus::MuteBtnDisable,
+            (Tab::Dynamics, Focus::MuteBtnDisable, DeviceModel::Mv6, _) => Focus::Hpf,
+            (Tab::Dynamics, Focus::Hpf, DeviceModel::Mv6, _) => Focus::Denoiser,
+            (Tab::Dynamics, _, DeviceModel::Mv6, _) => Focus::Denoiser,
+
+            // ── MVX2U Dynamics ────────────────────────────────────────────────
+            (Tab::Dynamics, Focus::Limiter, DeviceModel::Mvx2u, _) => Focus::Compressor,
+            (Tab::Dynamics, Focus::Compressor, DeviceModel::Mvx2u, _) => Focus::Hpf,
+            (Tab::Dynamics, Focus::Hpf, DeviceModel::Mvx2u, _) => Focus::Limiter,
+            (Tab::Dynamics, _, DeviceModel::Mvx2u, _) => Focus::Limiter,
+
+            (Tab::Presets, Focus::PresetName(i), _, _) => Focus::PresetActions(*i),
+            (Tab::Presets, Focus::PresetActions(i), _, _) => {
+                Focus::PresetName((i + 1) % PRESET_COUNT)
+            }
+            (Tab::Presets, _, _, _) => Focus::PresetName(0),
 
             _ => self.focus,
         };
     }
 
     pub fn focus_prev(&mut self) {
-        self.focus = match (&self.active_tab, &self.focus, &self.device_state.mode) {
-            // Manual cycle reverse
-            (Tab::Main, Focus::Mode, InputMode::Manual) => Focus::Lock,
-            (Tab::Main, Focus::Mute, InputMode::Manual) => Focus::Mode,
-            (Tab::Main, Focus::Gain, InputMode::Manual) => Focus::Mute,
-            // Auto cycle reverse
-            (Tab::Main, Focus::Mode, InputMode::Auto) => Focus::Lock,
-            (Tab::Main, Focus::Mute, InputMode::Auto) => Focus::Mode,
-            (Tab::Main, Focus::AutoPosition, InputMode::Auto) => Focus::Mute,
-            (Tab::Main, Focus::AutoTone, InputMode::Auto) => Focus::AutoPosition,
-            (Tab::Main, Focus::AutoGain, InputMode::Auto) => Focus::AutoTone,
-            // Shared tail (both modes)
-            (Tab::Main, Focus::MonitorMix, InputMode::Manual) => Focus::Gain,
-            (Tab::Main, Focus::MonitorMix, InputMode::Auto) => Focus::AutoGain,
-            (Tab::Main, Focus::Phantom, _) => Focus::MonitorMix,
-            (Tab::Main, Focus::Lock, _) => Focus::Phantom,
-            // Fallback
-            (Tab::Main, _, InputMode::Manual) => Focus::Mode,
-            (Tab::Main, _, InputMode::Auto) => Focus::Mode,
+        self.focus = match (&self.active_tab, &self.focus, &self.device_model, &self.device_state.mode) {
+            // ── MV6 Main reverse ──────────────────────────────────────────────
+            (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Manual) => Focus::GainLock,
+            (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Manual) => Focus::Mode,
+            (Tab::Main, Focus::Gain, DeviceModel::Mv6, InputMode::Manual) => Focus::Mute,
+            (Tab::Main, Focus::GainLock, DeviceModel::Mv6, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, _, DeviceModel::Mv6, _) => Focus::Mode,
 
-            (Tab::Eq, Focus::EqEnable, _) => Focus::EqGain(self.eq_selected_band),
-            (Tab::Eq, Focus::EqBandSelect, _) => Focus::EqEnable,
-            (Tab::Eq, Focus::EqBandEnable(_), _) => Focus::EqBandSelect,
-            (Tab::Eq, Focus::EqGain(b), _) => Focus::EqBandEnable(*b),
-            (Tab::Eq, _, _) => Focus::EqEnable,
+            // ── MVX2U Manual reverse ──────────────────────────────────────────
+            (Tab::Main, Focus::Mode, DeviceModel::Mvx2u, InputMode::Manual) => Focus::Lock,
+            (Tab::Main, Focus::Mute, DeviceModel::Mvx2u, InputMode::Manual) => Focus::Mode,
+            (Tab::Main, Focus::Gain, DeviceModel::Mvx2u, InputMode::Manual) => Focus::Mute,
+            // ── MVX2U Auto reverse ────────────────────────────────────────────
+            (Tab::Main, Focus::Mode, DeviceModel::Mvx2u, InputMode::Auto) => Focus::Lock,
+            (Tab::Main, Focus::Mute, DeviceModel::Mvx2u, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, Focus::AutoPosition, DeviceModel::Mvx2u, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::AutoTone, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoPosition,
+            (Tab::Main, Focus::AutoGain, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoTone,
+            // ── MVX2U shared tail reverse ─────────────────────────────────────
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mvx2u, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoGain,
+            (Tab::Main, Focus::Phantom, DeviceModel::Mvx2u, _) => Focus::MonitorMix,
+            (Tab::Main, Focus::Lock, DeviceModel::Mvx2u, _) => Focus::Phantom,
+            (Tab::Main, _, DeviceModel::Mvx2u, _) => Focus::Mode,
 
-            (Tab::Dynamics, Focus::Limiter, _) => Focus::Hpf,
-            (Tab::Dynamics, Focus::Compressor, _) => Focus::Limiter,
-            (Tab::Dynamics, Focus::Hpf, _) => Focus::Compressor,
-            (Tab::Dynamics, _, _) => Focus::Limiter,
+            // ── MV6 EQ ────────────────────────────────────────────────────────
+            (Tab::Eq, _, DeviceModel::Mv6, _) => Focus::Tone,
 
-            (Tab::Presets, Focus::PresetName(0), _) => Focus::PresetActions(PRESET_COUNT - 1),
-            (Tab::Presets, Focus::PresetName(i), _) => Focus::PresetActions(i - 1),
-            (Tab::Presets, Focus::PresetActions(i), _) => Focus::PresetName(*i),
-            (Tab::Presets, _, _) => Focus::PresetName(0),
+            // ── MVX2U EQ reverse ──────────────────────────────────────────────
+            (Tab::Eq, Focus::EqEnable, DeviceModel::Mvx2u, _) => Focus::EqGain(self.eq_selected_band),
+            (Tab::Eq, Focus::EqBandSelect, DeviceModel::Mvx2u, _) => Focus::EqEnable,
+            (Tab::Eq, Focus::EqBandEnable(_), DeviceModel::Mvx2u, _) => Focus::EqBandSelect,
+            (Tab::Eq, Focus::EqGain(b), DeviceModel::Mvx2u, _) => Focus::EqBandEnable(*b),
+            (Tab::Eq, _, DeviceModel::Mvx2u, _) => Focus::EqEnable,
+
+            // ── MV6 Dynamics reverse ──────────────────────────────────────────
+            (Tab::Dynamics, Focus::Denoiser, DeviceModel::Mv6, _) => Focus::Hpf,
+            (Tab::Dynamics, Focus::PopperStopper, DeviceModel::Mv6, _) => Focus::Denoiser,
+            (Tab::Dynamics, Focus::MuteBtnDisable, DeviceModel::Mv6, _) => Focus::PopperStopper,
+            (Tab::Dynamics, Focus::Hpf, DeviceModel::Mv6, _) => Focus::MuteBtnDisable,
+            (Tab::Dynamics, _, DeviceModel::Mv6, _) => Focus::Denoiser,
+
+            // ── MVX2U Dynamics reverse ────────────────────────────────────────
+            (Tab::Dynamics, Focus::Limiter, DeviceModel::Mvx2u, _) => Focus::Hpf,
+            (Tab::Dynamics, Focus::Compressor, DeviceModel::Mvx2u, _) => Focus::Limiter,
+            (Tab::Dynamics, Focus::Hpf, DeviceModel::Mvx2u, _) => Focus::Compressor,
+            (Tab::Dynamics, _, DeviceModel::Mvx2u, _) => Focus::Limiter,
+
+            (Tab::Presets, Focus::PresetName(0), _, _) => Focus::PresetActions(PRESET_COUNT - 1),
+            (Tab::Presets, Focus::PresetName(i), _, _) => Focus::PresetActions(i - 1),
+            (Tab::Presets, Focus::PresetActions(i), _, _) => Focus::PresetName(*i),
+            (Tab::Presets, _, _, _) => Focus::PresetName(0),
 
             _ => self.focus,
         };
@@ -291,12 +351,12 @@ impl App {
     pub fn adjust_focused(&mut self, delta: i32) -> Option<DeviceAction> {
         match self.focus {
             Focus::Gain => {
-                let g = &mut self.device_state.gain_db;
-                if delta > 0 {
-                    *g = (*g + 1).min(60);
-                } else {
-                    *g = g.saturating_sub(1);
+                if self.device_state.mv6_gain_locked {
+                    return None;
                 }
+                let max = self.device_model.max_gain_db() as i32;
+                let g = &mut self.device_state.gain_db;
+                *g = ((*g as i32) + delta).clamp(0, max) as u8;
                 Some(DeviceAction::SetGain(self.device_state.gain_db))
             }
             Focus::MonitorMix => {
@@ -308,6 +368,11 @@ impl App {
                 }
                 Some(DeviceAction::SetMonitorMix(self.device_state.monitor_mix))
             }
+            Focus::Tone => {
+                let t = &mut self.device_state.tone;
+                *t = ((*t as i32) + delta).clamp(-10, 10) as i8;
+                Some(DeviceAction::SetMv6Tone(self.device_state.tone))
+            }
             Focus::EqBandSelect => {
                 if delta > 0 {
                     self.eq_selected_band = (self.eq_selected_band + 1) % 5;
@@ -318,7 +383,6 @@ impl App {
             }
             Focus::EqGain(b) => {
                 let band = &mut self.device_state.eq_bands[b];
-                // Hardware supports −8 to +6 in steps of 2.
                 let new_gain = ((band.gain_db as i32) + delta * 2).clamp(-8, 6) as i8;
                 band.gain_db = new_gain;
                 Some(DeviceAction::SetEqBandGain(b, band.gain_db))
@@ -335,8 +399,6 @@ impl App {
                     InputMode::Auto => InputMode::Manual,
                     InputMode::Manual => InputMode::Auto,
                 };
-                // Jump focus to the first relevant control for the new mode so
-                // the user doesn't end up on a control that no longer exists.
                 self.focus = match self.device_state.mode {
                     InputMode::Auto => Focus::AutoPosition,
                     InputMode::Manual => Focus::Gain,
@@ -392,8 +454,33 @@ impl App {
                 self.device_state.hpf = self.device_state.hpf.cycle_next();
                 Some(DeviceAction::SetHpf(self.device_state.hpf))
             }
+            // ── MV6 Dynamics controls ─────────────────────────────────────────
+            Focus::Denoiser => {
+                self.device_state.denoiser_enabled = !self.device_state.denoiser_enabled;
+                Some(DeviceAction::SetMv6Denoiser(
+                    self.device_state.denoiser_enabled,
+                ))
+            }
+            Focus::PopperStopper => {
+                self.device_state.popper_stopper_enabled =
+                    !self.device_state.popper_stopper_enabled;
+                Some(DeviceAction::SetMv6PopperStopper(
+                    self.device_state.popper_stopper_enabled,
+                ))
+            }
+            Focus::MuteBtnDisable => {
+                self.device_state.mute_btn_disabled = !self.device_state.mute_btn_disabled;
+                Some(DeviceAction::SetMv6MuteBtnDisable(
+                    self.device_state.mute_btn_disabled,
+                ))
+            }
+            Focus::GainLock => {
+                self.device_state.mv6_gain_locked = !self.device_state.mv6_gain_locked;
+                Some(DeviceAction::SetMv6GainLock(
+                    self.device_state.mv6_gain_locked,
+                ))
+            }
             Focus::PresetActions(i) => {
-                // Enter on the actions row loads the preset (if filled).
                 if self.presets[i].is_some() {
                     Some(DeviceAction::LoadPreset(i))
                 } else {
@@ -426,6 +513,14 @@ pub enum DeviceAction {
     SetEqBandEnable(usize, bool),
     /// `usize` is band index 0–4; `i8` is gain in dB (−8..+6, steps of 2).
     SetEqBandGain(usize, i8),
+    // ── MV6-specific actions ──────────────────────────────────────────────────
+    SetMv6Denoiser(bool),
+    SetMv6PopperStopper(bool),
+    SetMv6MuteBtnDisable(bool),
+    /// Tone in steps of 1 (−10 to +10); displayed as × 10%.
+    SetMv6Tone(i8),
+    SetMv6GainLock(bool),
+    // ── Preset actions ────────────────────────────────────────────────────────
     /// Save current device state to preset slot `usize`.
     SavePreset(usize),
     /// Load preset slot `usize` and apply all settings to the device.
@@ -673,6 +768,37 @@ mod tests {
     }
 
     #[test]
+    fn mv6_main_tab_manual_mode_focus_cycles_forward_and_back() {
+        // MV6 Manual: Mode → Mute → Gain → GainLock → Mode
+        let forward = [
+            Focus::Mode,
+            Focus::Mute,
+            Focus::Gain,
+            Focus::GainLock,
+            Focus::Mode, // wrap
+        ];
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mv6;
+        app.active_tab = Tab::Main;
+        app.device_state.mode = InputMode::Manual;
+        app.focus = Focus::Mode;
+
+        for expected in &forward[1..] {
+            app.focus_next();
+            assert_eq!(app.focus, *expected, "focus_next: expected {expected:?}");
+        }
+
+        // Backward from Mode wraps to GainLock
+        app.focus = Focus::Mode;
+        app.focus_prev();
+        assert_eq!(app.focus, Focus::GainLock);
+
+        // Backward from GainLock goes to Gain
+        app.focus_prev();
+        assert_eq!(app.focus, Focus::Gain);
+    }
+
+    #[test]
     fn dynamics_tab_focus_cycles_all_three_controls() {
         let mut app = App::default();
         app.active_tab = Tab::Dynamics;
@@ -841,6 +967,7 @@ mod tests {
             Focus::Mute,
             Focus::Phantom,
             Focus::Lock,
+            Focus::GainLock,
             Focus::None,
         ] {
             app.focus = focus;
@@ -849,6 +976,32 @@ mod tests {
                 "{focus:?} should return None from adjust_focused"
             );
         }
+    }
+
+    #[test]
+    fn adjust_gain_blocked_when_mv6_gain_locked() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mv6;
+        app.focus = Focus::Gain;
+        app.device_state.gain_db = 20;
+        app.device_state.mv6_gain_locked = true;
+
+        let action = app.adjust_focused(1);
+        assert!(action.is_none(), "adjust must return None when gain is locked");
+        assert_eq!(app.device_state.gain_db, 20, "gain must not change when locked");
+    }
+
+    #[test]
+    fn adjust_gain_allowed_when_mv6_gain_unlocked() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mv6;
+        app.focus = Focus::Gain;
+        app.device_state.gain_db = 20;
+        app.device_state.mv6_gain_locked = false;
+
+        let action = app.adjust_focused(1);
+        assert!(matches!(action, Some(DeviceAction::SetGain(21))));
+        assert_eq!(app.device_state.gain_db, 21);
     }
 
     // ── toggle_focused ────────────────────────────────────────────────────────
@@ -1010,6 +1163,22 @@ mod tests {
     }
 
     #[test]
+    fn toggle_gain_lock_flips_state_and_returns_action() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mv6;
+        app.focus = Focus::GainLock;
+        app.device_state.mv6_gain_locked = false;
+
+        let action = app.toggle_focused();
+        assert!(app.device_state.mv6_gain_locked);
+        assert!(matches!(action, Some(DeviceAction::SetMv6GainLock(true))));
+
+        let action = app.toggle_focused();
+        assert!(!app.device_state.mv6_gain_locked);
+        assert!(matches!(action, Some(DeviceAction::SetMv6GainLock(false))));
+    }
+
+    #[test]
     fn toggle_phantom_flips_state_and_returns_action() {
         let mut app = App::default();
         app.focus = Focus::Phantom;
@@ -1159,6 +1328,11 @@ mod tests {
                 enabled: false,
                 gain_db: 0,
             }; 5],
+            denoiser_enabled: false,
+            popper_stopper_enabled: true,
+            mute_btn_disabled: false,
+            tone: 0,
+            mv6_gain_locked: false,
         });
 
         let action = app.toggle_focused();

--- a/src/app.rs
+++ b/src/app.rs
@@ -227,7 +227,12 @@ impl App {
     // MV6 EQ:      Tone (slider only, no bands)
     // MV6 Dynamics: Denoiser → PopperStopper → MuteBtnDisable → Hpf → (wrap)
     pub fn focus_next(&mut self) {
-        self.focus = match (&self.active_tab, &self.focus, &self.device_model, &self.device_state.mode) {
+        self.focus = match (
+            &self.active_tab,
+            &self.focus,
+            &self.device_model,
+            &self.device_state.mode,
+        ) {
             // ── MV6 Main cycle ────────────────────────────────────────────────
             (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Manual) => Focus::Mute,
             (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Manual) => Focus::Gain,
@@ -244,7 +249,9 @@ impl App {
             // ── MVX2U Auto cycle ──────────────────────────────────────────────
             (Tab::Main, Focus::Mode, DeviceModel::Mvx2u, InputMode::Auto) => Focus::Mute,
             (Tab::Main, Focus::Mute, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoPosition,
-            (Tab::Main, Focus::AutoPosition, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoTone,
+            (Tab::Main, Focus::AutoPosition, DeviceModel::Mvx2u, InputMode::Auto) => {
+                Focus::AutoTone
+            }
             (Tab::Main, Focus::AutoTone, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoGain,
             (Tab::Main, Focus::AutoGain, DeviceModel::Mvx2u, InputMode::Auto) => Focus::MonitorMix,
             // ── MVX2U shared tail ─────────────────────────────────────────────
@@ -258,7 +265,9 @@ impl App {
 
             // ── MVX2U EQ ──────────────────────────────────────────────────────
             (Tab::Eq, Focus::EqEnable, DeviceModel::Mvx2u, _) => Focus::EqBandSelect,
-            (Tab::Eq, Focus::EqBandSelect, DeviceModel::Mvx2u, _) => Focus::EqBandEnable(self.eq_selected_band),
+            (Tab::Eq, Focus::EqBandSelect, DeviceModel::Mvx2u, _) => {
+                Focus::EqBandEnable(self.eq_selected_band)
+            }
             (Tab::Eq, Focus::EqBandEnable(b), DeviceModel::Mvx2u, _) => Focus::EqGain(*b),
             (Tab::Eq, Focus::EqGain(_), DeviceModel::Mvx2u, _) => Focus::EqEnable,
             (Tab::Eq, _, DeviceModel::Mvx2u, _) => Focus::EqEnable,
@@ -287,7 +296,12 @@ impl App {
     }
 
     pub fn focus_prev(&mut self) {
-        self.focus = match (&self.active_tab, &self.focus, &self.device_model, &self.device_state.mode) {
+        self.focus = match (
+            &self.active_tab,
+            &self.focus,
+            &self.device_model,
+            &self.device_state.mode,
+        ) {
             // ── MV6 Main reverse ──────────────────────────────────────────────
             (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Manual) => Focus::GainLock,
             (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Manual) => Focus::Mode,
@@ -305,7 +319,9 @@ impl App {
             (Tab::Main, Focus::Mode, DeviceModel::Mvx2u, InputMode::Auto) => Focus::Lock,
             (Tab::Main, Focus::Mute, DeviceModel::Mvx2u, InputMode::Auto) => Focus::Mode,
             (Tab::Main, Focus::AutoPosition, DeviceModel::Mvx2u, InputMode::Auto) => Focus::Mute,
-            (Tab::Main, Focus::AutoTone, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoPosition,
+            (Tab::Main, Focus::AutoTone, DeviceModel::Mvx2u, InputMode::Auto) => {
+                Focus::AutoPosition
+            }
             (Tab::Main, Focus::AutoGain, DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoTone,
             // ── MVX2U shared tail reverse ─────────────────────────────────────
             (Tab::Main, Focus::MonitorMix, DeviceModel::Mvx2u, InputMode::Manual) => Focus::Gain,
@@ -318,7 +334,9 @@ impl App {
             (Tab::Eq, _, DeviceModel::Mv6, _) => Focus::Tone,
 
             // ── MVX2U EQ reverse ──────────────────────────────────────────────
-            (Tab::Eq, Focus::EqEnable, DeviceModel::Mvx2u, _) => Focus::EqGain(self.eq_selected_band),
+            (Tab::Eq, Focus::EqEnable, DeviceModel::Mvx2u, _) => {
+                Focus::EqGain(self.eq_selected_band)
+            }
             (Tab::Eq, Focus::EqBandSelect, DeviceModel::Mvx2u, _) => Focus::EqEnable,
             (Tab::Eq, Focus::EqBandEnable(_), DeviceModel::Mvx2u, _) => Focus::EqBandSelect,
             (Tab::Eq, Focus::EqGain(b), DeviceModel::Mvx2u, _) => Focus::EqBandEnable(*b),
@@ -987,8 +1005,14 @@ mod tests {
         app.device_state.mv6_gain_locked = true;
 
         let action = app.adjust_focused(1);
-        assert!(action.is_none(), "adjust must return None when gain is locked");
-        assert_eq!(app.device_state.gain_db, 20, "gain must not change when locked");
+        assert!(
+            action.is_none(),
+            "adjust must return None when gain is locked"
+        );
+        assert_eq!(
+            app.device_state.gain_db, 20,
+            "gain must not change when locked"
+        );
     }
 
     #[test]

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,15 +1,12 @@
-//! Device I/O: wraps hidapi for the MVX2U.
+//! Device I/O: wraps hidapi for Shure USB microphones.
 //!
-//! The MVX2U exposes three USB interfaces:
-//!   Interface 0 – USB Audio (class 0x01, handled by the kernel's snd-usb-audio)
-//!   Interface 1 – USB Audio streaming
-//!   Interface 2 – HID configuration (the one we need)
+//! Supports two devices:
+//!   - Shure MVX2U (VID 0x14ED, PID 0x1013) — XLR-to-USB interface
+//!   - Shure MV6   (VID 0x14ED, PID 0x1026) — USB gaming microphone
 //!
-//! hidapi opens the HID configuration interface (interface 2) by matching VID/PID.
-//! On Linux, snd-usb-audio claims the audio interfaces, but hidapi uses /dev/hidrawN
-//! for the HID interface, bypassing the audio driver entirely — no kernel detach needed.
-//! On macOS, IOHidManager opens the HID interface alongside CoreAudio; the
-//! `macos-shared-device` hidapi feature enables non-exclusive access for this.
+//! Both devices expose a USB HID configuration interface alongside their
+//! audio interface. hidapi opens the HID interface via /dev/hidrawN on Linux,
+//! bypassing the audio driver entirely.
 //!
 //! # Transport
 //!
@@ -24,112 +21,145 @@
 //! # Sequence numbers
 //!
 //! Each packet carries an incrementing sequence number (0–255, wrapping). The
-//! device echoes this number in its response. We track it in `Mvx2u` and
+//! device echoes this number in its response. We track it in `ShureDevice` and
 //! increment after every `write()`.
+//!
+//! # Multi-device
+//!
+//! If only one Shure device is plugged in, `open()` opens it automatically.
+//! If multiple Shure devices are detected, `open()` returns an error directing
+//! the user to specify one with `--device`. Use `list_devices()` to enumerate.
 
 use std::sync::atomic::{AtomicU8, Ordering};
 
 use anyhow::{Context, Result, anyhow};
+use hidapi::{HidApi, HidDevice};
+
+use crate::protocol::{
+    self, DeviceModel, DeviceState, MV6_PID, PACKET_SIZE, PID, VID, apply_response, cmd_confirm,
+    cmd_get_auto_gain, cmd_get_auto_position, cmd_get_auto_tone, cmd_get_compressor,
+    cmd_get_eq_band_enable, cmd_get_eq_band_gain, cmd_get_eq_enable, cmd_get_gain, cmd_get_hpf,
+    cmd_get_limiter, cmd_get_lock, cmd_get_mix, cmd_get_mode, cmd_get_mute, cmd_get_phantom,
+    cmd_get_mv6_denoiser,
+    cmd_get_mv6_popper_stopper, cmd_get_mv6_tone, cmd_get_mv6_gain_lock, cmd_set_lock, parse_response,
+};
 
 #[cfg(target_os = "linux")]
 const ACCESS_HINT: &str = "ensure the udev rule is installed, or run with sudo";
 #[cfg(not(target_os = "linux"))]
 const ACCESS_HINT: &str = "ensure the device is plugged in and accessible";
-use hidapi::{HidApi, HidDevice};
-
-use crate::protocol::{
-    self, DeviceState, PACKET_SIZE, PID, VID, apply_response, cmd_confirm, cmd_get_auto_gain,
-    cmd_get_auto_position, cmd_get_auto_tone, cmd_get_compressor, cmd_get_eq_band_enable,
-    cmd_get_eq_band_gain, cmd_get_eq_enable, cmd_get_gain, cmd_get_hpf, cmd_get_limiter,
-    cmd_get_lock, cmd_get_mix, cmd_get_mode, cmd_get_mute, cmd_get_phantom, cmd_set_lock,
-    parse_response,
-};
 
 /// How long to wait for a read response, in milliseconds.
 const READ_TIMEOUT_MS: i32 = 200;
 
-pub struct Mvx2u {
+/// A connected Shure USB microphone (MVX2U or MV6).
+pub struct ShureDevice {
     device: HidDevice,
+    /// Which device model this is — drives protocol and UI decisions.
+    pub model: DeviceModel,
     /// Packet sequence number. Increments after every write; wraps at 256.
     seq: AtomicU8,
     /// Serial number string read from the USB device descriptor at open time.
     pub serial_number: String,
 }
 
-impl Mvx2u {
-    /// Wrap an already-opened `HidDevice` into `Mvx2u`, reading the serial
-    /// number from the USB device descriptor.
-    fn from_hid_device(device: HidDevice) -> Self {
+impl ShureDevice {
+    fn from_hid_device(device: HidDevice, pid: u16) -> Self {
         device.set_blocking_mode(false).ok();
-        // Serial number is read from the USB string descriptor at open time —
-        // no HID packet exchange required.
         let serial_number = device
             .get_serial_number_string()
             .ok()
             .flatten()
             .unwrap_or_else(|| "(unknown)".to_string());
+        let model = if pid == MV6_PID {
+            DeviceModel::Mv6
+        } else {
+            DeviceModel::Mvx2u
+        };
         Self {
             device,
+            model,
             seq: AtomicU8::new(0),
             serial_number,
         }
     }
 
-    /// Open the first MVX2U found on the system.
+    /// Open the first (and only) Shure device found on the system.
+    ///
+    /// Returns an error if zero or more than one Shure device is detected.
+    /// Use `--device` to select a specific device when multiple are present.
     pub fn open() -> Result<Self> {
         let api = HidApi::new().context("Failed to initialise hidapi")?;
-        let device = api.open(VID, PID).map_err(|e| {
-            anyhow!(
-                "Cannot open MVX2U (VID={:#06x} PID={:#06x}): {e}\n\
-                Hint: {ACCESS_HINT}.",
-                VID,
-                PID
-            )
-        })?;
-        Ok(Self::from_hid_device(device))
+
+        // Deduplicate by path — some devices expose multiple HID interfaces
+        // and hidapi enumerates each one separately under the same path.
+        let mut seen_paths = std::collections::HashSet::new();
+        let found: Vec<_> = api
+            .device_list()
+            .filter(|d| {
+                d.vendor_id() == VID
+                    && (d.product_id() == PID || d.product_id() == MV6_PID)
+                    && seen_paths.insert(d.path().to_string_lossy().into_owned())
+            })
+            .collect();
+
+        match found.len() {
+            0 => Err(anyhow!(
+                "No Shure MVX2U or MV6 device found.\nHint: {ACCESS_HINT}."
+            )),
+            1 => {
+                let info = found[0];
+                let pid = info.product_id();
+                let c_path =
+                    std::ffi::CString::new(info.path().to_string_lossy().as_ref())
+                        .map_err(|_| anyhow!("Device path contains a null byte"))?;
+                let device = api
+                    .open_path(c_path.as_c_str())
+                    .map_err(|e| anyhow!("Cannot open device: {e}\nHint: {ACCESS_HINT}."))?;
+                Ok(Self::from_hid_device(device, pid))
+            }
+            n => Err(anyhow!(
+                "{n} Shure devices found. Use --device to specify one.\n\
+                Run --list to see available devices and their paths."
+            )),
+        }
     }
 
-    /// Open the MVX2U at a specific HID device path (use `--list` to find paths).
-    ///
-    /// Returns an error if the path is not found in the device list or does
-    /// not identify a Shure MVX2U (VID/PID mismatch).
+    /// Open a Shure device at a specific HID device path.
     pub fn open_path(path: &str) -> Result<Self> {
         let api = HidApi::new().context("Failed to initialise hidapi")?;
-        // Validate the path against the enumerated device list before opening.
-        // This catches both "no such hidraw node" and "wrong device type" with
-        // clear error messages, rather than a generic hidapi open failure.
         let info = api
             .device_list()
             .find(|d| d.path().to_string_lossy() == path)
             .ok_or_else(|| {
                 anyhow!("No device found at {path}. Use --list to see available devices.")
             })?;
-        if info.vendor_id() != VID || info.product_id() != PID {
+
+        let pid = info.product_id();
+        if info.vendor_id() != VID || (pid != PID && pid != MV6_PID) {
             return Err(anyhow!(
-                "{path} is not a Shure MVX2U (VID={:#06x} PID={:#06x}); \
-                expected VID={:#06x} PID={:#06x}.",
+                "{path} is not a supported Shure device \
+                (VID={:#06x} PID={:#06x}); expected VID={:#06x} with PID={:#06x} or {:#06x}.",
                 info.vendor_id(),
-                info.product_id(),
+                pid,
                 VID,
-                PID
+                PID,
+                MV6_PID,
             ));
         }
-        // Open by path. We validated above that this path exists and matches
-        // VID/PID, so any remaining error here is a permissions problem.
+
         let c_path = std::ffi::CString::new(path)
             .map_err(|_| anyhow!("Device path contains a null byte: {path}"))?;
         let device = api
             .open_path(c_path.as_c_str())
             .map_err(|e| anyhow!("Cannot open {path}: {e}\nHint: {ACCESS_HINT}."))?;
-        Ok(Self::from_hid_device(device))
+        Ok(Self::from_hid_device(device, pid))
     }
 
-    /// Return the next sequence number and post-increment it (wraps at 256).
     fn next_seq(&self) -> u8 {
         self.seq.fetch_add(1, Ordering::Relaxed)
     }
 
-    /// Write one packet to the device.
     fn write(&self, packet: &[u8]) -> Result<()> {
         let written = self.device.write(packet).context("HID write failed")?;
         if written == 0 {
@@ -138,10 +168,6 @@ impl Mvx2u {
         Ok(())
     }
 
-    /// Read one HID report, blocking up to `READ_TIMEOUT_MS`.
-    ///
-    /// Returns the raw bytes on success, or `Err` if the read failed (which
-    /// typically means the device was disconnected).
     fn read(&self) -> Result<Vec<u8>> {
         let mut buf = vec![0u8; PACKET_SIZE];
         match self.device.read_timeout(&mut buf, READ_TIMEOUT_MS) {
@@ -151,34 +177,29 @@ impl Mvx2u {
         }
     }
 
-    /// Send a SET command followed by a CONFIRM packet.
-    ///
-    /// Every SET on the MVX2U must be confirmed; the device will not apply the
-    /// change without the subsequent CONFIRM.
     fn send_set(&self, set_packet: &[u8]) -> Result<()> {
         self.write(set_packet)?;
         let confirm = cmd_confirm(self.next_seq());
         self.write(&confirm)
     }
 
-    /// Send a GET command and read back the response.
-    ///
-    /// Returns `Ok(Some((feat_addr, value)))` on a valid response, or
-    /// `Ok(None)` if the response was a CONFIRM or failed to parse.
     fn send_get(&self, get_packet: &[u8]) -> Result<Option<([u8; 2], Vec<u8>)>> {
         self.write(get_packet)?;
         let buf = self.read()?;
         Ok(parse_response(&buf))
     }
 
-    /// Fetch the complete device state by querying every feature individually.
-    ///
-    /// Returns a partially-filled `DeviceState` if some queries time out;
-    /// a hard `Err` is returned only if the transport itself fails.
+    /// Fetch the complete device state by querying every feature for this model.
     pub fn get_state(&self) -> Result<DeviceState> {
+        match self.model {
+            DeviceModel::Mvx2u => self.get_state_mvx2u(),
+            DeviceModel::Mv6 => self.get_state_mv6(),
+        }
+    }
+
+    fn get_state_mvx2u(&self) -> Result<DeviceState> {
         let mut state = DeviceState::default();
 
-        // Query lock state first — it is on a separate command class.
         let lock_pkt = cmd_get_lock(self.next_seq());
         if let Ok(Some((feat, value))) = self.send_get(&lock_pkt)
             && !apply_response(feat, &value, &mut state)
@@ -186,8 +207,6 @@ impl Mvx2u {
             eprintln!("get_state: unrecognised feature {feat:#04x?} in lock response");
         }
 
-        // Query every feature in order. Errors on individual reads are non-fatal
-        // (the default value stays in place); transport errors propagate.
         let getters: &[fn(u8) -> Vec<u8>] = &[
             cmd_get_gain,
             cmd_get_mute,
@@ -212,7 +231,6 @@ impl Mvx2u {
             }
         }
 
-        // EQ bands: enable + gain for each of the 5 bands
         for band in 0..5 {
             let en_pkt = cmd_get_eq_band_enable(self.next_seq(), band);
             if let Ok(Some((feat, value))) = self.send_get(&en_pkt)
@@ -235,69 +253,89 @@ impl Mvx2u {
         Ok(state)
     }
 
-    // ── SET commands ──────────────────────────────────────────────────────────
+    fn get_state_mv6(&self) -> Result<DeviceState> {
+        let mut state = DeviceState::default();
 
-    /// Set manual gain (0–60 dB).
-    pub fn set_gain(&self, gain_db: u8) -> Result<()> {
-        self.send_set(&protocol::cmd_set_gain(self.next_seq(), gain_db))
+        // MV6 shares gain, mute, HPF, and auto level addresses with the MVX2U.
+        // mute_btn_disabled is persisted host-side (see presets::Mv6State) because
+        // the device always returns the same value for that GET regardless of state.
+        let getters: &[fn(u8) -> Vec<u8>] = &[
+            cmd_get_gain,
+            cmd_get_mute,
+            cmd_get_hpf,
+            cmd_get_mode,
+            cmd_get_mv6_denoiser,
+            cmd_get_mv6_popper_stopper,
+            cmd_get_mv6_tone,
+            cmd_get_mv6_gain_lock,
+        ];
+
+        for getter in getters {
+            let pkt = getter(self.next_seq());
+            if let Ok(Some((feat, value))) = self.send_get(&pkt)
+                && !apply_response(feat, &value, &mut state)
+            {
+                eprintln!("get_state(mv6): unrecognised feature {feat:#04x?} in response");
+            }
+        }
+
+        Ok(state)
     }
 
-    /// Set input mode. `auto = true` selects Auto Level; `false` selects Manual.
+    // ── Shared SET commands ───────────────────────────────────────────────────
+
+    /// Set manual gain. Clamped to the model's maximum (60 dB MVX2U, 36 dB MV6).
+    pub fn set_gain(&self, gain_db: u8) -> Result<()> {
+        let clamped = gain_db.min(self.model.max_gain_db());
+        self.send_set(&protocol::cmd_set_gain(self.next_seq(), clamped))
+    }
+
     pub fn set_mode(&self, auto: bool) -> Result<()> {
         self.send_set(&protocol::cmd_set_mode(self.next_seq(), auto))
     }
 
-    /// Set mic position for Auto Level mode.
-    pub fn set_auto_position(&self, position: &protocol::MicPosition) -> Result<()> {
-        self.send_set(&protocol::cmd_set_auto_position(self.next_seq(), position))
-    }
-
-    /// Set tone preset for Auto Level mode.
-    pub fn set_auto_tone(&self, tone: &protocol::AutoTone) -> Result<()> {
-        self.send_set(&protocol::cmd_set_auto_tone(self.next_seq(), tone))
-    }
-
-    /// Set gain preset for Auto Level mode.
-    pub fn set_auto_gain(&self, gain: &protocol::AutoGain) -> Result<()> {
-        self.send_set(&protocol::cmd_set_auto_gain(self.next_seq(), gain))
-    }
-
-    /// Mute or unmute the microphone input.
     pub fn set_mute(&self, muted: bool) -> Result<()> {
         self.send_set(&protocol::cmd_set_mute(self.next_seq(), muted))
     }
 
-    /// Enable or disable 48 V phantom power.
-    pub fn set_phantom(&self, enabled: bool) -> Result<()> {
-        self.send_set(&protocol::cmd_set_phantom(self.next_seq(), enabled))
-    }
-
-    /// Set the direct-monitor mix (0–100). 0 = 100% mic; 100 = 100% playback.
-    pub fn set_monitor_mix(&self, mix: u8) -> Result<()> {
-        self.send_set(&protocol::cmd_set_mix(self.next_seq(), mix))
-    }
-
-    /// Enable or disable the output limiter.
-    pub fn set_limiter(&self, enabled: bool) -> Result<()> {
-        self.send_set(&protocol::cmd_set_limiter(self.next_seq(), enabled))
-    }
-
-    /// Set the compressor preset.
-    pub fn set_compressor(&self, preset: &protocol::CompressorPreset) -> Result<()> {
-        self.send_set(&protocol::cmd_set_compressor(self.next_seq(), preset))
-    }
-
-    /// Set the high-pass filter frequency.
     pub fn set_hpf(&self, freq: &protocol::HpfFrequency) -> Result<()> {
         self.send_set(&protocol::cmd_set_hpf(self.next_seq(), freq))
     }
 
-    /// Enable or disable the 5-band parametric EQ.
+    // ── MVX2U-only SET commands ───────────────────────────────────────────────
+
+    pub fn set_auto_position(&self, position: &protocol::MicPosition) -> Result<()> {
+        self.send_set(&protocol::cmd_set_auto_position(self.next_seq(), position))
+    }
+
+    pub fn set_auto_tone(&self, tone: &protocol::AutoTone) -> Result<()> {
+        self.send_set(&protocol::cmd_set_auto_tone(self.next_seq(), tone))
+    }
+
+    pub fn set_auto_gain(&self, gain: &protocol::AutoGain) -> Result<()> {
+        self.send_set(&protocol::cmd_set_auto_gain(self.next_seq(), gain))
+    }
+
+    pub fn set_phantom(&self, enabled: bool) -> Result<()> {
+        self.send_set(&protocol::cmd_set_phantom(self.next_seq(), enabled))
+    }
+
+    pub fn set_monitor_mix(&self, mix: u8) -> Result<()> {
+        self.send_set(&protocol::cmd_set_mix(self.next_seq(), mix))
+    }
+
+    pub fn set_limiter(&self, enabled: bool) -> Result<()> {
+        self.send_set(&protocol::cmd_set_limiter(self.next_seq(), enabled))
+    }
+
+    pub fn set_compressor(&self, preset: &protocol::CompressorPreset) -> Result<()> {
+        self.send_set(&protocol::cmd_set_compressor(self.next_seq(), preset))
+    }
+
     pub fn set_eq_enable(&self, enabled: bool) -> Result<()> {
         self.send_set(&protocol::cmd_set_eq_enable(self.next_seq(), enabled))
     }
 
-    /// Set an EQ band's enabled state. `band` is 0–4.
     pub fn set_eq_band_enable(&self, band: usize, enabled: bool) -> Result<()> {
         self.send_set(&protocol::cmd_set_eq_band_enable(
             self.next_seq(),
@@ -306,7 +344,6 @@ impl Mvx2u {
         ))
     }
 
-    /// Set an EQ band's gain (−8 to +6 dB, steps of 2). `band` is 0–4.
     pub fn set_eq_band_gain(&self, band: usize, gain_db: i8) -> Result<()> {
         self.send_set(&protocol::cmd_set_eq_band_gain(
             self.next_seq(),
@@ -315,33 +352,66 @@ impl Mvx2u {
         ))
     }
 
-    // ── Lock ──────────────────────────────────────────────────────────────────
-
-    /// Lock or unlock the device configuration.
-    /// When locked, the device ignores all SET commands until unlocked.
     pub fn set_lock(&self, locked: bool) -> Result<()> {
         self.send_set(&cmd_set_lock(self.next_seq(), locked))
     }
+
+    // ── MV6-only SET commands ─────────────────────────────────────────────────
+
+    pub fn set_mv6_denoiser(&self, enabled: bool) -> Result<()> {
+        self.send_set(&protocol::cmd_set_mv6_denoiser(self.next_seq(), enabled))
+    }
+
+    pub fn set_mv6_popper_stopper(&self, enabled: bool) -> Result<()> {
+        self.send_set(&protocol::cmd_set_mv6_popper_stopper(
+            self.next_seq(),
+            enabled,
+        ))
+    }
+
+    pub fn set_mv6_mute_btn_disable(&self, disabled: bool) -> Result<()> {
+        self.send_set(&protocol::cmd_set_mv6_mute_btn_disable(
+            self.next_seq(),
+            disabled,
+        ))
+    }
+
+    pub fn set_mv6_tone(&self, tone: i8) -> Result<()> {
+        self.send_set(&protocol::cmd_set_mv6_tone(self.next_seq(), tone))
+    }
+
+    pub fn set_mv6_gain_lock(&self, locked: bool) -> Result<()> {
+        self.send_set(&protocol::cmd_set_mv6_gain_lock(self.next_seq(), locked))
+    }
 }
 
-/// Information about a detected MVX2U, returned by [`list_devices`].
+/// Information about a detected Shure device, returned by [`list_devices`].
 pub struct DeviceInfo {
-    /// Platform-specific HID device path (e.g. `/dev/hidraw3` on Linux).
     pub path: String,
-    /// USB serial number string, e.g. `MVX2U#3-7d84d19...`.
     pub serial: String,
+    pub model: DeviceModel,
 }
 
-/// Probe the system for MVX2U devices without opening them.
+/// Probe the system for supported Shure devices without opening them.
 pub fn list_devices() -> Vec<DeviceInfo> {
     let Ok(api) = HidApi::new() else {
         return vec![];
     };
+    let mut seen_paths = std::collections::HashSet::new();
     api.device_list()
-        .filter(|d| d.vendor_id() == VID && d.product_id() == PID)
+        .filter(|d| {
+            d.vendor_id() == VID
+                && (d.product_id() == PID || d.product_id() == MV6_PID)
+                && seen_paths.insert(d.path().to_string_lossy().into_owned())
+        })
         .map(|d| DeviceInfo {
             path: d.path().to_string_lossy().into_owned(),
             serial: d.serial_number().unwrap_or("(unknown)").to_owned(),
+            model: if d.product_id() == MV6_PID {
+                DeviceModel::Mv6
+            } else {
+                DeviceModel::Mvx2u
+            },
         })
         .collect()
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -39,9 +39,9 @@ use crate::protocol::{
     self, DeviceModel, DeviceState, MV6_PID, PACKET_SIZE, PID, VID, apply_response, cmd_confirm,
     cmd_get_auto_gain, cmd_get_auto_position, cmd_get_auto_tone, cmd_get_compressor,
     cmd_get_eq_band_enable, cmd_get_eq_band_gain, cmd_get_eq_enable, cmd_get_gain, cmd_get_hpf,
-    cmd_get_limiter, cmd_get_lock, cmd_get_mix, cmd_get_mode, cmd_get_mute, cmd_get_phantom,
-    cmd_get_mv6_denoiser,
-    cmd_get_mv6_popper_stopper, cmd_get_mv6_tone, cmd_get_mv6_gain_lock, cmd_set_lock, parse_response,
+    cmd_get_limiter, cmd_get_lock, cmd_get_mix, cmd_get_mode, cmd_get_mute, cmd_get_mv6_denoiser,
+    cmd_get_mv6_gain_lock, cmd_get_mv6_popper_stopper, cmd_get_mv6_tone, cmd_get_phantom,
+    cmd_set_lock, parse_response,
 };
 
 #[cfg(target_os = "linux")]
@@ -110,9 +110,8 @@ impl ShureDevice {
             1 => {
                 let info = found[0];
                 let pid = info.product_id();
-                let c_path =
-                    std::ffi::CString::new(info.path().to_string_lossy().as_ref())
-                        .map_err(|_| anyhow!("Device path contains a null byte"))?;
+                let c_path = std::ffi::CString::new(info.path().to_string_lossy().as_ref())
+                    .map_err(|_| anyhow!("Device path contains a null byte"))?;
                 let device = api
                     .open_path(c_path.as_c_str())
                     .map_err(|e| anyhow!("Cannot open device: {e}\nHint: {ACCESS_HINT}."))?;

--- a/src/device.rs
+++ b/src/device.rs
@@ -96,11 +96,7 @@ impl ShureDevice {
         let mut seen_paths = std::collections::HashSet::new();
         let found: Vec<_> = api
             .device_list()
-            .filter(|d| {
-                d.vendor_id() == VID
-                    && (d.product_id() == PID || d.product_id() == MV6_PID)
-                    && seen_paths.insert(d.path().to_string_lossy().into_owned())
-            })
+            .filter(|d| is_shure_device(d, &mut seen_paths))
             .collect();
 
         match found.len() {
@@ -188,6 +184,18 @@ impl ShureDevice {
         Ok(parse_response(&buf))
     }
 
+    /// Send each getter, apply the response to `state`, and log any unrecognised features.
+    fn run_getters(&self, getters: &[fn(u8) -> Vec<u8>], state: &mut DeviceState, context: &str) {
+        for getter in getters {
+            let pkt = getter(self.next_seq());
+            if let Ok(Some((feat, value))) = self.send_get(&pkt)
+                && !apply_response(feat, &value, state)
+            {
+                eprintln!("{context}: unrecognised feature {feat:#04x?} in response");
+            }
+        }
+    }
+
     /// Fetch the complete device state by querying every feature for this model.
     pub fn get_state(&self) -> Result<DeviceState> {
         match self.model {
@@ -221,14 +229,7 @@ impl ShureDevice {
             cmd_get_eq_enable,
         ];
 
-        for getter in getters {
-            let pkt = getter(self.next_seq());
-            if let Ok(Some((feat, value))) = self.send_get(&pkt)
-                && !apply_response(feat, &value, &mut state)
-            {
-                eprintln!("get_state: unrecognised feature {feat:#04x?} in response");
-            }
-        }
+        self.run_getters(getters, &mut state, "get_state");
 
         for band in 0..5 {
             let en_pkt = cmd_get_eq_band_enable(self.next_seq(), band);
@@ -269,14 +270,7 @@ impl ShureDevice {
             cmd_get_mv6_gain_lock,
         ];
 
-        for getter in getters {
-            let pkt = getter(self.next_seq());
-            if let Ok(Some((feat, value))) = self.send_get(&pkt)
-                && !apply_response(feat, &value, &mut state)
-            {
-                eprintln!("get_state(mv6): unrecognised feature {feat:#04x?} in response");
-            }
-        }
+        self.run_getters(getters, &mut state, "get_state(mv6)");
 
         Ok(state)
     }
@@ -391,6 +385,19 @@ pub struct DeviceInfo {
     pub model: DeviceModel,
 }
 
+/// Returns `true` if `d` is a supported Shure device that has not been seen before.
+///
+/// `seen_paths` is used to deduplicate entries — hidapi may enumerate the same
+/// physical device multiple times when it exposes more than one HID interface.
+fn is_shure_device(
+    d: &hidapi::DeviceInfo,
+    seen_paths: &mut std::collections::HashSet<String>,
+) -> bool {
+    d.vendor_id() == VID
+        && (d.product_id() == PID || d.product_id() == MV6_PID)
+        && seen_paths.insert(d.path().to_string_lossy().into_owned())
+}
+
 /// Probe the system for supported Shure devices without opening them.
 pub fn list_devices() -> Vec<DeviceInfo> {
     let Ok(api) = HidApi::new() else {
@@ -398,11 +405,7 @@ pub fn list_devices() -> Vec<DeviceInfo> {
     };
     let mut seen_paths = std::collections::HashSet::new();
     api.device_list()
-        .filter(|d| {
-            d.vendor_id() == VID
-                && (d.product_id() == PID || d.product_id() == MV6_PID)
-                && seen_paths.insert(d.path().to_string_lossy().into_owned())
-        })
+        .filter(|d| is_shure_device(d, &mut seen_paths))
         .map(|d| DeviceInfo {
             path: d.path().to_string_lossy().into_owned(),
             serial: d.serial_number().unwrap_or("(unknown)").to_owned(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,12 @@ fn main() -> Result<()> {
         } else {
             println!("Found {} Shure device(s):", devs.len());
             for d in devs {
-                println!("  {} | {} | S/N: {}", d.path, d.model.display_name(), d.serial);
+                println!(
+                    "  {} | {} | S/N: {}",
+                    d.path,
+                    d.model.display_name(),
+                    d.serial
+                );
             }
         }
         return Ok(());
@@ -391,7 +396,10 @@ fn apply_action(app: &mut App, device: &Option<ShureDevice>, action: DeviceActio
             send_if_connected(device, |d| d.set_mv6_denoiser(*en))
         }
         DeviceAction::SetMv6PopperStopper(en) => {
-            app.set_ok(format!("Popper Stopper → {}", if *en { "ON" } else { "OFF" }));
+            app.set_ok(format!(
+                "Popper Stopper → {}",
+                if *en { "ON" } else { "OFF" }
+            ));
             send_if_connected(device, |d| d.set_mv6_popper_stopper(*en))
         }
         DeviceAction::SetMv6MuteBtnDisable(disabled) => {
@@ -452,9 +460,10 @@ fn apply_action(app: &mut App, device: &Option<ShureDevice>, action: DeviceActio
                 if app.device_model == DeviceModel::Mv6
                     && let Err(e) = presets::save_mv6_state(&presets::Mv6State {
                         mute_btn_disabled: app.device_state.mute_btn_disabled,
-                    }) {
-                        eprintln!("Warning: failed to persist MV6 state after preset load: {e}");
-                    }
+                    })
+                {
+                    eprintln!("Warning: failed to persist MV6 state after preset load: {e}");
+                }
                 result
             } else {
                 app.set_err(format!("Preset slot {} is empty.", i + 1));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,14 @@
-//! shurectl — Interactive TUI configurator for the Shure MVX2U
+//! shurectl — Interactive TUI configurator for Shure USB microphones
+//!
+//! Supports:
+//!   - Shure MVX2U (XLR-to-USB audio interface)
+//!   - Shure MV6   (USB gaming microphone)
 //!
 //! Usage:
 //!   shurectl               # Connect to device, launch TUI
 //!   shurectl --demo        # Run without a device (for testing)
 //!   shurectl --list        # List detected devices and exit
-//!
-//! See README.md for platform-specific setup and permissions.
+//!   shurectl --device PATH # Open a specific device by HID path
 
 mod app;
 mod device;
@@ -21,37 +24,35 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use clap::Parser;
 use crossterm::{
-    event::{
-        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
-    },
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
 use app::{App, DeviceAction};
-use device::Mvx2u;
+use device::ShureDevice;
 use meter::{MeterStatus, start_meter};
 use presets::PresetSlot;
-use protocol::InputMode;
+use protocol::{DeviceModel, InputMode};
 
 #[derive(Parser)]
 #[command(
     name = "shurectl",
     version,
-    about = "shurectl — TUI configurator for the Shure MVX2U audio interface"
+    about = "shurectl — TUI configurator for Shure MVX2U and MV6 USB microphones"
 )]
 struct Cli {
     /// Run in demo mode without a real device
     #[arg(long, short)]
     demo: bool,
 
-    /// List connected MVX2U devices and exit
+    /// List connected Shure devices and exit
     #[arg(long, short)]
     list: bool,
 
     /// Open a specific device by its HID path.
-    /// Without this flag, the first detected MVX2U is opened.
+    /// Without this flag, the first detected device is opened (error if multiple found).
     /// Use --list to see available paths.
     #[arg(long, short = 'D')]
     device: Option<String>,
@@ -63,15 +64,15 @@ fn main() -> Result<()> {
     if cli.list {
         let devs = device::list_devices();
         if devs.is_empty() {
-            println!("No Shure MVX2U devices found.");
+            println!("No Shure MVX2U or MV6 devices found.");
             #[cfg(target_os = "linux")]
             println!("Check that the device is plugged in and the udev rule is installed.");
             #[cfg(not(target_os = "linux"))]
             println!("Check that the device is plugged in and accessible.");
         } else {
-            println!("Found {} MVX2U device(s):", devs.len());
+            println!("Found {} Shure device(s):", devs.len());
             for d in devs {
-                println!("  {} | S/N: {}", d.path, d.serial);
+                println!("  {} | {} | S/N: {}", d.path, d.model.display_name(), d.serial);
             }
         }
         return Ok(());
@@ -81,9 +82,9 @@ fn main() -> Result<()> {
         (None, true)
     } else {
         let open_result = if let Some(ref path) = cli.device {
-            Mvx2u::open_path(path)
+            ShureDevice::open_path(path)
         } else {
-            Mvx2u::open()
+            ShureDevice::open()
         };
         match open_result {
             Ok(d) => (Some(d), false),
@@ -95,8 +96,14 @@ fn main() -> Result<()> {
         }
     };
 
+    let device_model = device
+        .as_ref()
+        .map(|d| d.model)
+        .unwrap_or(DeviceModel::Mvx2u);
+
     let mut app = App {
         demo_mode,
+        device_model,
         ..App::default()
     };
 
@@ -104,8 +111,15 @@ fn main() -> Result<()> {
         match dev.get_state() {
             Ok(mut state) => {
                 state.serial_number = dev.serial_number.clone();
+                if dev.model == DeviceModel::Mv6 {
+                    let mv6 = presets::load_mv6_state();
+                    state.mute_btn_disabled = mv6.mute_btn_disabled;
+                }
                 app.device_state = state;
-                app.set_ok("Connected — state loaded from device.");
+                app.set_ok(format!(
+                    "Connected to {} — state loaded.",
+                    dev.model.display_name()
+                ));
             }
             Err(e) => {
                 app.set_err(format!("Connected but failed to read state: {e}"));
@@ -117,8 +131,6 @@ fn main() -> Result<()> {
 
     app.presets = presets::load_all_presets();
 
-    // Start the input level meter. _meter_stream must stay alive —
-    // dropping it stops the capture thread.
     let _meter_stream = if !demo_mode {
         match start_meter(Arc::clone(&app.meter_level), Arc::clone(&app.peak_window)) {
             MeterStatus::Running(s) => Some(s),
@@ -133,18 +145,14 @@ fn main() -> Result<()> {
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
     let result = run_event_loop(&mut terminal, &mut app, &device);
 
     disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
 
     if let Err(e) = result {
@@ -157,7 +165,7 @@ fn main() -> Result<()> {
 fn run_event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
-    device: &Option<Mvx2u>,
+    device: &Option<ShureDevice>,
 ) -> Result<()> {
     let tick_rate = Duration::from_millis(100);
     let mut last_tick = Instant::now();
@@ -193,7 +201,6 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
     if matches!(code, KeyCode::Char('q') | KeyCode::Char('Q'))
         || (code == KeyCode::Char('c') && mods.contains(KeyModifiers::CONTROL))
     {
-        // Quit is blocked while editing a preset name — Esc must be used first.
         if !app.editing_preset_name {
             app.should_quit = true;
         }
@@ -206,7 +213,6 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
             KeyCode::Enter | KeyCode::Esc => {
                 app.editing_preset_name = false;
                 let i = app.editing_preset_index;
-                // Persist the updated name if the slot is filled.
                 if app.presets[i].is_some() {
                     return Some(DeviceAction::PersistPresetName(i));
                 }
@@ -219,11 +225,10 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
             }
             KeyCode::Char(c) if !mods.contains(KeyModifiers::CONTROL) => {
                 let i = app.editing_preset_index;
-                if let Some(slot) = &mut app.presets[i] {
-                    // Cap name length at 40 characters.
-                    if slot.name.len() < 40 {
-                        slot.name.push(c);
-                    }
+                if let Some(slot) = &mut app.presets[i]
+                    && slot.name.len() < 40
+                {
+                    slot.name.push(c);
                 }
             }
             _ => {}
@@ -263,7 +268,6 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
         KeyCode::Left | KeyCode::Char('h') => app.adjust_focused(-1),
         KeyCode::Right | KeyCode::Char('l') => app.adjust_focused(1),
         KeyCode::Enter | KeyCode::Char(' ') => {
-            // On PresetName: enter edit mode.
             if let app::Focus::PresetName(i) = app.focus
                 && app.presets[i].is_some()
             {
@@ -273,7 +277,6 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
             }
             app.toggle_focused()
         }
-        // Preset-specific keys — only active on the Presets tab.
         KeyCode::Char('s') if app.active_tab == app::Tab::Presets => {
             if let app::Focus::PresetName(i) | app::Focus::PresetActions(i) = app.focus {
                 Some(DeviceAction::SavePreset(i))
@@ -296,7 +299,7 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
     }
 }
 
-fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
+fn apply_action(app: &mut App, device: &Option<ShureDevice>, action: DeviceAction) {
     let result = match &action {
         DeviceAction::Refresh => {
             if let Some(dev) = device {
@@ -344,7 +347,7 @@ fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
         }
         DeviceAction::SetLock(locked) => {
             if *locked {
-                app.set_ok("Device locked — SET commands will be ignored until unlocked.");
+                app.set_ok("Device locked.");
             } else {
                 app.set_ok("Device unlocked.");
             }
@@ -382,6 +385,48 @@ fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
             app.set_ok(format!("EQ Band {} → {:+} dB", band + 1, gain_db));
             send_if_connected(device, |d| d.set_eq_band_gain(*band, *gain_db))
         }
+        // ── MV6 actions ───────────────────────────────────────────────────────
+        DeviceAction::SetMv6Denoiser(en) => {
+            app.set_ok(format!("Denoiser → {}", if *en { "ON" } else { "OFF" }));
+            send_if_connected(device, |d| d.set_mv6_denoiser(*en))
+        }
+        DeviceAction::SetMv6PopperStopper(en) => {
+            app.set_ok(format!("Popper Stopper → {}", if *en { "ON" } else { "OFF" }));
+            send_if_connected(device, |d| d.set_mv6_popper_stopper(*en))
+        }
+        DeviceAction::SetMv6MuteBtnDisable(disabled) => {
+            app.set_ok(format!(
+                "Mute Button → {}",
+                if *disabled { "Disabled" } else { "Enabled" }
+            ));
+            if let Err(e) = presets::save_mv6_state(&presets::Mv6State {
+                mute_btn_disabled: *disabled,
+            }) {
+                eprintln!("Warning: failed to save MV6 state: {e}");
+            }
+            send_if_connected(device, |d| d.set_mv6_mute_btn_disable(*disabled))
+        }
+        DeviceAction::SetMv6Tone(tone) => {
+            let pct = *tone as i32 * 10;
+            let label = if pct < 0 {
+                format!("{}% Dark", pct.abs())
+            } else if pct > 0 {
+                format!("{}% Bright", pct)
+            } else {
+                "Natural".to_string()
+            };
+            app.set_ok(format!("Tone → {label}"));
+            send_if_connected(device, |d| d.set_mv6_tone(*tone))
+        }
+        DeviceAction::SetMv6GainLock(locked) => {
+            app.set_ok(if *locked {
+                "Gain locked.".to_string()
+            } else {
+                "Gain unlocked.".to_string()
+            });
+            send_if_connected(device, |d| d.set_mv6_gain_lock(*locked))
+        }
+        // ── Preset actions ────────────────────────────────────────────────────
         DeviceAction::SavePreset(i) => {
             let name = app.presets[*i]
                 .as_ref()
@@ -401,8 +446,16 @@ fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
             if let Some(slot) = &app.presets[*i].clone() {
                 slot.apply_to_device_state(&mut app.device_state);
                 app.set_ok(format!("Loaded \"{}\".", slot.name));
-                // Apply every setting to the device.
-                apply_preset_to_device(device, &app.device_state)
+                let result = apply_preset_to_device(device, &app.device_state, app.device_model);
+                // mute_btn_disabled cannot be read back from the MV6, so we persist
+                // the preset value to mv6_state.toml so a restart doesn't revert it.
+                if app.device_model == DeviceModel::Mv6
+                    && let Err(e) = presets::save_mv6_state(&presets::Mv6State {
+                        mute_btn_disabled: app.device_state.mute_btn_disabled,
+                    }) {
+                        eprintln!("Warning: failed to persist MV6 state after preset load: {e}");
+                    }
+                result
             } else {
                 app.set_err(format!("Preset slot {} is empty.", i + 1));
                 Ok(())
@@ -440,9 +493,9 @@ fn apply_action(app: &mut App, device: &Option<Mvx2u>, action: DeviceAction) {
     }
 }
 
-fn send_if_connected<F>(device: &Option<Mvx2u>, f: F) -> Result<()>
+fn send_if_connected<F>(device: &Option<ShureDevice>, f: F) -> Result<()>
 where
-    F: FnOnce(&Mvx2u) -> Result<()>,
+    F: FnOnce(&ShureDevice) -> Result<()>,
 {
     match device {
         Some(dev) => f(dev),
@@ -452,23 +505,38 @@ where
 
 /// Send every configurable field of `state` to the device.
 /// Called after loading a preset to bring the hardware into sync.
-fn apply_preset_to_device(device: &Option<Mvx2u>, state: &protocol::DeviceState) -> Result<()> {
+fn apply_preset_to_device(
+    device: &Option<ShureDevice>,
+    state: &protocol::DeviceState,
+    model: DeviceModel,
+) -> Result<()> {
     send_if_connected(device, |d| {
         d.set_mode(state.mode == InputMode::Auto)?;
         d.set_gain(state.gain_db)?;
-        d.set_auto_position(&state.auto_position)?;
-        d.set_auto_tone(&state.auto_tone)?;
-        d.set_auto_gain(&state.auto_gain)?;
         d.set_mute(state.muted)?;
-        d.set_phantom(state.phantom_power)?;
-        d.set_monitor_mix(state.monitor_mix)?;
-        d.set_limiter(state.limiter_enabled)?;
-        d.set_compressor(&state.compressor)?;
         d.set_hpf(&state.hpf)?;
-        d.set_eq_enable(state.eq_enabled)?;
-        for (band, eq) in state.eq_bands.iter().enumerate() {
-            d.set_eq_band_enable(band, eq.enabled)?;
-            d.set_eq_band_gain(band, eq.gain_db)?;
+        match model {
+            DeviceModel::Mvx2u => {
+                d.set_auto_position(&state.auto_position)?;
+                d.set_auto_tone(&state.auto_tone)?;
+                d.set_auto_gain(&state.auto_gain)?;
+                d.set_phantom(state.phantom_power)?;
+                d.set_monitor_mix(state.monitor_mix)?;
+                d.set_limiter(state.limiter_enabled)?;
+                d.set_compressor(&state.compressor)?;
+                d.set_eq_enable(state.eq_enabled)?;
+                for (band, eq) in state.eq_bands.iter().enumerate() {
+                    d.set_eq_band_enable(band, eq.enabled)?;
+                    d.set_eq_band_gain(band, eq.gain_db)?;
+                }
+            }
+            DeviceModel::Mv6 => {
+                d.set_mv6_denoiser(state.denoiser_enabled)?;
+                d.set_mv6_popper_stopper(state.popper_stopper_enabled)?;
+                d.set_mv6_mute_btn_disable(state.mute_btn_disabled)?;
+                d.set_mv6_tone(state.tone)?;
+                d.set_mv6_gain_lock(state.mv6_gain_locked)?;
+            }
         }
         Ok(())
     })

--- a/src/meter.rs
+++ b/src/meter.rs
@@ -12,7 +12,7 @@
 //!   peak into both windows; the render thread reads the rolling maxima to
 //!   drive the bar ratio and the peak-hold marker respectively.
 //!
-//! We deliberately do NOT search for the MVX2U by name. On Linux, cpal's
+//! We deliberately do NOT search for the device by name. On Linux, cpal's
 //! default ALSA host would find the raw `hw:MVX2U` PCM device and open it
 //! exclusively, preventing any other application (PipeWire, PulseAudio, DAW)
 //! from capturing audio until shurectl exits. Using the default input

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -5,7 +5,7 @@
 //!
 //! Each file is human-readable and hand-editable. The preset captures all
 //! configurable DSP settings from `DeviceState` — everything that can be sent
-//! to the MVX2U over HID. Hardware-identity fields `serial_number` are intentionally excluded.
+//! to the device over HID. Hardware-identity fields `serial_number` are intentionally excluded.
 //!
 //! This mirrors how MOTIV Desktop saves presets: the app sends a batch of SET
 //! commands when a preset is loaded, with no device-side preset bank involved.
@@ -16,36 +16,65 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::{
-    AutoGain, AutoTone, CompressorPreset, DeviceState, EqBand, HpfFrequency, InputMode, MicPosition,
+    AutoGain, AutoTone, CompressorPreset, DeviceModel, DeviceState, EqBand, HpfFrequency,
+    InputMode, MicPosition,
 };
 
 pub const PRESET_COUNT: usize = 4;
 
 /// A serializable snapshot of all configurable device settings.
+///
+/// Fields from both MVX2U and MV6 are included. Fields irrelevant to a given
+/// device model remain at their serde defaults and are not applied to the device.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct PresetSlot {
     /// Human-readable name shown in the TUI (editable in-app or by hand in TOML).
     pub name: String,
 
-    // ── Main ─────────────────────────────────────────────────────────────────
+    // ── Shared ───────────────────────────────────────────────────────────────
     pub gain_db: u8,
     pub mode: SerInputMode,
-    pub auto_position: SerMicPosition,
-    pub auto_tone: SerAutoTone,
-    pub auto_gain: SerAutoGain,
     pub muted: bool,
-    pub phantom_power: bool,
-    /// Monitor mix: 0 = 100% mic, 100 = 100% playback.
-    pub monitor_mix: u8,
-
-    // ── Dynamics ─────────────────────────────────────────────────────────────
-    pub limiter_enabled: bool,
-    pub compressor: SerCompressorPreset,
     pub hpf: SerHpfFrequency,
 
-    // ── EQ ───────────────────────────────────────────────────────────────────
+    // ── MVX2U-specific ───────────────────────────────────────────────────────
+    #[serde(default)]
+    pub auto_position: SerMicPosition,
+    #[serde(default)]
+    pub auto_tone: SerAutoTone,
+    #[serde(default)]
+    pub auto_gain: SerAutoGain,
+    #[serde(default)]
+    pub phantom_power: bool,
+    #[serde(default)]
+    /// Monitor mix: 0 = 100% mic, 100 = 100% playback.
+    pub monitor_mix: u8,
+    #[serde(default)]
+    pub limiter_enabled: bool,
+    #[serde(default)]
+    pub compressor: SerCompressorPreset,
+    #[serde(default)]
     pub eq_enabled: bool,
+    #[serde(default)]
     pub eq_bands: [SerEqBand; 5],
+
+    // ── MV6-specific ─────────────────────────────────────────────────────────
+    #[serde(default)]
+    pub denoiser_enabled: bool,
+    #[serde(default = "default_popper_stopper")]
+    pub popper_stopper_enabled: bool,
+    #[serde(default)]
+    pub mute_btn_disabled: bool,
+    /// Tone: -10 (100% Dark) to +10 (100% Bright), 0 = Natural.
+    #[serde(default)]
+    pub tone: i8,
+    /// Gain lock (Manual mode only). MV6 only.
+    #[serde(default)]
+    pub mv6_gain_locked: bool,
+}
+
+fn default_popper_stopper() -> bool {
+    true
 }
 
 impl PresetSlot {
@@ -55,17 +84,22 @@ impl PresetSlot {
             name: name.into(),
             gain_db: state.gain_db,
             mode: SerInputMode::from(state.mode),
+            muted: state.muted,
+            hpf: SerHpfFrequency::from(state.hpf),
             auto_position: SerMicPosition::from(state.auto_position),
             auto_tone: SerAutoTone::from(state.auto_tone),
             auto_gain: SerAutoGain::from(state.auto_gain),
-            muted: state.muted,
             phantom_power: state.phantom_power,
             monitor_mix: state.monitor_mix,
             limiter_enabled: state.limiter_enabled,
             compressor: SerCompressorPreset::from(state.compressor),
-            hpf: SerHpfFrequency::from(state.hpf),
             eq_enabled: state.eq_enabled,
             eq_bands: state.eq_bands.map(SerEqBand::from),
+            denoiser_enabled: state.denoiser_enabled,
+            popper_stopper_enabled: state.popper_stopper_enabled,
+            mute_btn_disabled: state.mute_btn_disabled,
+            tone: state.tone,
+            mv6_gain_locked: state.mv6_gain_locked,
         }
     }
 
@@ -74,44 +108,75 @@ impl PresetSlot {
     pub fn apply_to_device_state(&self, state: &mut DeviceState) {
         state.gain_db = self.gain_db;
         state.mode = InputMode::from(self.mode);
+        state.muted = self.muted;
+        state.hpf = HpfFrequency::from(self.hpf);
         state.auto_position = MicPosition::from(self.auto_position);
         state.auto_tone = AutoTone::from(self.auto_tone);
         state.auto_gain = AutoGain::from(self.auto_gain);
-        state.muted = self.muted;
         state.phantom_power = self.phantom_power;
         state.monitor_mix = self.monitor_mix;
         state.limiter_enabled = self.limiter_enabled;
         state.compressor = CompressorPreset::from(self.compressor);
-        state.hpf = HpfFrequency::from(self.hpf);
         state.eq_enabled = self.eq_enabled;
         state.eq_bands = self.eq_bands.map(EqBand::from);
+        state.denoiser_enabled = self.denoiser_enabled;
+        state.popper_stopper_enabled = self.popper_stopper_enabled;
+        state.mute_btn_disabled = self.mute_btn_disabled;
+        state.tone = self.tone;
+        state.mv6_gain_locked = self.mv6_gain_locked;
     }
 
     /// One-line summary of the key settings for display in the TUI.
-    pub fn summary(&self) -> String {
-        let phantom_str = if self.phantom_power {
-            "48V on"
-        } else {
-            "48V off"
+    ///
+    /// The model is needed because MVX2U and MV6 have different configurable
+    /// fields — showing EQ/phantom for an MV6 preset (or denoiser for an MVX2U
+    /// preset) would be misleading.
+    pub fn summary(&self, model: DeviceModel) -> String {
+        let hpf_str = match HpfFrequency::from(self.hpf) {
+            HpfFrequency::Off => "HPF off".to_string(),
+            freq => format!("HPF {freq}"),
         };
-        match InputMode::from(self.mode) {
-            InputMode::Auto => {
-                let tone = AutoTone::from(self.auto_tone);
-                let gain = AutoGain::from(self.auto_gain);
-                let pos = MicPosition::from(self.auto_position);
-                format!("Auto · {tone} · {gain} · {pos} · {phantom_str}")
-            }
-            InputMode::Manual => {
-                let eq_str = if self.eq_enabled { "EQ on" } else { "EQ off" };
-                let comp_str = CompressorPreset::from(self.compressor).to_string();
-                let hpf_str = match HpfFrequency::from(self.hpf) {
-                    HpfFrequency::Off => "HPF off".to_string(),
-                    freq => format!("HPF {freq}"),
+
+        match model {
+            DeviceModel::Mv6 => {
+                let denoiser_str = if self.denoiser_enabled {
+                    "Denoiser on"
+                } else {
+                    "Denoiser off"
+                };
+                let popper_str = if self.popper_stopper_enabled {
+                    "Popper on"
+                } else {
+                    "Popper off"
+                };
+                let tone_str = match self.tone {
+                    0 => "Natural".to_string(),
+                    t if t > 0 => format!("{}% Bright", t as i32 * 10),
+                    t => format!("{}% Dark", (t as i32 * 10).abs()),
                 };
                 format!(
-                    "Manual · {}dB · {eq_str} · Comp: {comp_str} · {phantom_str} · {hpf_str}",
+                    "{}dB · {denoiser_str} · {popper_str} · {hpf_str} · Tone: {tone_str}",
                     self.gain_db
                 )
+            }
+            DeviceModel::Mvx2u => {
+                let phantom_str = if self.phantom_power { "48V on" } else { "48V off" };
+                match InputMode::from(self.mode) {
+                    InputMode::Auto => {
+                        let tone = AutoTone::from(self.auto_tone);
+                        let gain = AutoGain::from(self.auto_gain);
+                        let pos = MicPosition::from(self.auto_position);
+                        format!("Auto · {tone} · {gain} · {pos} · {phantom_str}")
+                    }
+                    InputMode::Manual => {
+                        let eq_str = if self.eq_enabled { "EQ on" } else { "EQ off" };
+                        let comp_str = CompressorPreset::from(self.compressor).to_string();
+                        format!(
+                            "Manual · {}dB · {eq_str} · Comp: {comp_str} · {phantom_str} · {hpf_str}",
+                            self.gain_db
+                        )
+                    }
+                }
             }
         }
     }
@@ -119,8 +184,8 @@ impl PresetSlot {
 
 // ── File I/O ──────────────────────────────────────────────────────────────────
 
-/// Returns `~/.config/shurectl/presets/`, creating it if absent.
-fn presets_dir() -> Result<PathBuf> {
+/// Returns `~/.config/shurectl/`, creating it if absent.
+fn config_dir() -> Result<PathBuf> {
     let base = dirs_next::config_dir()
         .or_else(|| {
             std::env::var("HOME")
@@ -128,7 +193,15 @@ fn presets_dir() -> Result<PathBuf> {
                 .map(|h| PathBuf::from(h).join(".config"))
         })
         .context("Cannot determine config directory; set $HOME")?;
-    let dir = base.join("shurectl").join("presets");
+    let dir = base.join("shurectl");
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create config directory: {}", dir.display()))?;
+    Ok(dir)
+}
+
+/// Returns `~/.config/shurectl/presets/`, creating it if absent.
+fn presets_dir() -> Result<PathBuf> {
+    let dir = config_dir()?.join("presets");
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("Failed to create preset directory: {}", dir.display()))?;
     Ok(dir)
@@ -142,33 +215,43 @@ pub fn preset_path(index: usize) -> Result<PathBuf> {
 /// Load the preset at `index`. Returns `None` if the slot file does not exist.
 pub fn load_preset(index: usize) -> Result<Option<PresetSlot>> {
     let path = preset_path(index)?;
-    if !path.exists() {
-        return Ok(None);
-    }
-    let text = std::fs::read_to_string(&path)
-        .with_context(|| format!("Failed to read preset file: {}", path.display()))?;
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(e).with_context(|| format!("Failed to read preset file: {}", path.display()))
+        }
+    };
     let slot: PresetSlot = toml::from_str(&text)
         .with_context(|| format!("Failed to parse preset file: {}", path.display()))?;
     Ok(Some(slot))
 }
 
 /// Save a preset to slot `index`, overwriting any existing file.
+///
+/// Uses a write-to-temp-then-rename pattern so a crash or power loss mid-write
+/// cannot leave a corrupt or empty preset file behind.
 pub fn save_preset(index: usize, slot: &PresetSlot) -> Result<()> {
     let path = preset_path(index)?;
     let text = toml::to_string_pretty(slot).context("Failed to serialise preset")?;
-    std::fs::write(&path, text)
-        .with_context(|| format!("Failed to write preset file: {}", path.display()))?;
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, &text)
+        .with_context(|| format!("Failed to write preset file: {}", tmp.display()))?;
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("Failed to rename preset file: {}", path.display()))?;
     Ok(())
 }
 
 /// Delete the preset file for slot `index`. No-op if the slot is already empty.
 pub fn delete_preset(index: usize) -> Result<()> {
     let path = preset_path(index)?;
-    if path.exists() {
-        std::fs::remove_file(&path)
-            .with_context(|| format!("Failed to delete preset file: {}", path.display()))?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => {
+            Err(e).with_context(|| format!("Failed to delete preset file: {}", path.display()))
+        }
     }
-    Ok(())
 }
 
 /// Load all 4 preset slots. Missing files produce `None` entries.
@@ -181,6 +264,46 @@ pub fn load_all_presets() -> [Option<PresetSlot>; PRESET_COUNT] {
             None
         }
     })
+}
+
+// ── MV6 persistent state ──────────────────────────────────────────────────────
+//
+// Some MV6 settings cannot be read back from the device (the mute button disable
+// state always returns the same value regardless of what was set). We persist
+// these host-side in ~/.config/shurectl/mv6_state.toml.
+
+/// Host-side persistent state for MV6 settings that cannot be read from the device.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct Mv6State {
+    /// Whether the physical mute button is disabled.
+    #[serde(default)]
+    pub mute_btn_disabled: bool,
+}
+
+/// Load MV6 persistent state from `~/.config/shurectl/mv6_state.toml`.
+/// Returns default (all false) if the file does not exist or cannot be parsed.
+pub fn load_mv6_state() -> Mv6State {
+    let path = match config_dir() {
+        Ok(dir) => dir.join("mv6_state.toml"),
+        Err(_) => return Mv6State::default(),
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(_) => return Mv6State::default(),
+    };
+    toml::from_str(&text).unwrap_or_default()
+}
+
+/// Save MV6 persistent state to `~/.config/shurectl/mv6_state.toml`.
+pub fn save_mv6_state(state: &Mv6State) -> Result<()> {
+    let path = config_dir()?.join("mv6_state.toml");
+    let text = toml::to_string_pretty(state).context("Failed to serialise MV6 state")?;
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, &text)
+        .with_context(|| format!("Failed to write MV6 state: {}", tmp.display()))?;
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("Failed to rename MV6 state file: {}", path.display()))?;
+    Ok(())
 }
 
 // ── Serialisable mirror types ─────────────────────────────────────────────────
@@ -215,9 +338,10 @@ impl From<SerInputMode> for InputMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SerMicPosition {
+    #[default]
     Near,
     Far,
 }
@@ -240,10 +364,11 @@ impl From<SerMicPosition> for MicPosition {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SerAutoTone {
     Dark,
+    #[default]
     Natural,
     Bright,
 }
@@ -268,10 +393,11 @@ impl From<SerAutoTone> for AutoTone {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SerAutoGain {
     Quiet,
+    #[default]
     Normal,
     Loud,
 }
@@ -296,9 +422,10 @@ impl From<SerAutoGain> for AutoGain {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SerCompressorPreset {
+    #[default]
     Off,
     Light,
     Medium,
@@ -355,7 +482,7 @@ impl From<SerHpfFrequency> for HpfFrequency {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 pub struct SerEqBand {
     pub enabled: bool,
     /// Gain in dB, range −8..+6.
@@ -388,7 +515,7 @@ mod tests {
 
     fn example_state() -> DeviceState {
         DeviceState {
-            gain_db: 42,
+            gain_db: 36,
             mode: InputMode::Manual,
             auto_position: MicPosition::Far,
             auto_tone: AutoTone::Bright,
@@ -401,28 +528,18 @@ mod tests {
             hpf: HpfFrequency::Hz75,
             eq_enabled: true,
             eq_bands: [
-                EqBand {
-                    enabled: true,
-                    gain_db: 4,
-                },
-                EqBand {
-                    enabled: false,
-                    gain_db: -2,
-                },
-                EqBand {
-                    enabled: true,
-                    gain_db: 0,
-                },
-                EqBand {
-                    enabled: false,
-                    gain_db: 6,
-                },
-                EqBand {
-                    enabled: true,
-                    gain_db: -8,
-                },
+                EqBand { enabled: true, gain_db: 4 },
+                EqBand { enabled: false, gain_db: -2 },
+                EqBand { enabled: true, gain_db: 0 },
+                EqBand { enabled: false, gain_db: 6 },
+                EqBand { enabled: true, gain_db: -8 },
             ],
             locked: false,
+            denoiser_enabled: true,
+            popper_stopper_enabled: false,
+            mute_btn_disabled: true,
+            tone: -5,
+            mv6_gain_locked: false,
             serial_number: String::from("TEST001"),
         }
     }
@@ -437,10 +554,13 @@ mod tests {
 
         assert_eq!(slot, decoded);
         assert_eq!(decoded.name, "My Preset");
-        assert_eq!(decoded.gain_db, 42);
-        assert_eq!(decoded.muted, true);
+        assert_eq!(decoded.gain_db, 36);
+        assert!(decoded.muted);
         assert_eq!(decoded.eq_bands[0].gain_db, 4);
         assert_eq!(decoded.eq_bands[4].gain_db, -8);
+        assert!(decoded.denoiser_enabled);
+        assert!(!decoded.popper_stopper_enabled);
+        assert_eq!(decoded.tone, -5);
     }
 
     #[test]
@@ -448,14 +568,12 @@ mod tests {
         let original = example_state();
         let slot = PresetSlot::from_device_state("Test", &original);
 
-        // Apply onto a default state (different values).
         let mut target = DeviceState::default();
-        // Preserve identity fields to confirm they are NOT overwritten.
         target.serial_number = String::from("OTHER");
 
         slot.apply_to_device_state(&mut target);
 
-        assert_eq!(target.gain_db, 42);
+        assert_eq!(target.gain_db, 36);
         assert_eq!(target.mode, InputMode::Manual);
         assert_eq!(target.auto_position, MicPosition::Far);
         assert_eq!(target.auto_tone, AutoTone::Bright);
@@ -468,6 +586,10 @@ mod tests {
         assert_eq!(target.hpf, HpfFrequency::Hz75);
         assert!(target.eq_enabled);
         assert_eq!(target.eq_bands[0].gain_db, 4);
+        assert!(target.denoiser_enabled);
+        assert!(!target.popper_stopper_enabled);
+        assert!(target.mute_btn_disabled);
+        assert_eq!(target.tone, -5);
         // Identity fields must be untouched.
         assert_eq!(target.serial_number, "OTHER");
     }
@@ -498,7 +620,7 @@ mod tests {
         state.phantom_power = true;
         state.hpf = HpfFrequency::Hz75;
         let slot = PresetSlot::from_device_state("S", &state);
-        let s = slot.summary();
+        let s = slot.summary(DeviceModel::Mvx2u);
         assert!(s.contains("Manual"), "summary: {s}");
         assert!(s.contains("36dB"), "summary: {s}");
         assert!(s.contains("EQ"), "summary: {s}");
@@ -516,7 +638,7 @@ mod tests {
         state.auto_position = MicPosition::Near;
         state.phantom_power = false;
         let slot = PresetSlot::from_device_state("S", &state);
-        let s = slot.summary();
+        let s = slot.summary(DeviceModel::Mvx2u);
         assert!(s.contains("Auto"), "summary: {s}");
         assert!(s.contains("Natural"), "summary: {s}");
         assert!(s.contains("Normal"), "summary: {s}");
@@ -529,5 +651,139 @@ mod tests {
             "Auto summary must not mention Comp: {s}"
         );
         assert!(!s.contains("HPF"), "Auto summary must not mention HPF: {s}");
+    }
+
+    fn mv6_example_state() -> DeviceState {
+        DeviceState {
+            gain_db: 24,
+            mode: InputMode::Manual,
+            auto_position: MicPosition::Near,
+            auto_tone: AutoTone::Natural,
+            auto_gain: AutoGain::Normal,
+            muted: false,
+            phantom_power: false,
+            monitor_mix: 0,
+            limiter_enabled: false,
+            compressor: CompressorPreset::Off,
+            hpf: HpfFrequency::Hz75,
+            eq_enabled: false,
+            eq_bands: [EqBand::default(); 5],
+            locked: false,
+            denoiser_enabled: true,
+            popper_stopper_enabled: true,
+            mute_btn_disabled: true,
+            tone: 5,
+            mv6_gain_locked: false,
+            serial_number: String::from("MV6TEST"),
+        }
+    }
+
+    #[test]
+    fn mv6_preset_roundtrip_toml() {
+        let state = mv6_example_state();
+        let slot = PresetSlot::from_device_state("MV6 Preset", &state);
+
+        let toml_str = toml::to_string_pretty(&slot).expect("serialise");
+        let decoded: PresetSlot = toml::from_str(&toml_str).expect("deserialise");
+
+        assert_eq!(slot, decoded);
+        assert_eq!(decoded.name, "MV6 Preset");
+        assert_eq!(decoded.gain_db, 24);
+        assert!(decoded.denoiser_enabled);
+        assert!(decoded.popper_stopper_enabled);
+        assert!(decoded.mute_btn_disabled);
+        assert_eq!(decoded.tone, 5);
+        assert_eq!(decoded.hpf, SerHpfFrequency::Hz75);
+    }
+
+    #[test]
+    fn mv6_apply_to_device_state_restores_mv6_fields() {
+        let original = mv6_example_state();
+        let slot = PresetSlot::from_device_state("MV6 Test", &original);
+
+        let mut target = DeviceState::default();
+        target.serial_number = String::from("OTHER");
+
+        slot.apply_to_device_state(&mut target);
+
+        assert_eq!(target.gain_db, 24);
+        assert!(target.denoiser_enabled);
+        assert!(target.popper_stopper_enabled);
+        assert!(target.mute_btn_disabled);
+        assert_eq!(target.tone, 5);
+        assert_eq!(target.hpf, HpfFrequency::Hz75);
+        // Identity fields must be untouched.
+        assert_eq!(target.serial_number, "OTHER");
+    }
+
+    #[test]
+    fn mv6_apply_to_device_state_no_duplicate_hpf() {
+        // Verifies the duplicate hpf assignment is gone: applying a preset with
+        // Hz150 must result in Hz150, not whatever was there before.
+        let mut state = mv6_example_state();
+        state.hpf = HpfFrequency::Hz150;
+        let slot = PresetSlot::from_device_state("HPF test", &state);
+
+        let mut target = DeviceState::default();
+        // target.hpf starts as HpfFrequency::Off (default).
+        slot.apply_to_device_state(&mut target);
+
+        assert_eq!(target.hpf, HpfFrequency::Hz150);
+    }
+
+    #[test]
+    fn mv6_mute_btn_disabled_roundtrip_file() {
+        let state = mv6_example_state(); // mute_btn_disabled = true
+        let slot = PresetSlot::from_device_state("MV6 File", &state);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("preset_1.toml");
+
+        let text = toml::to_string_pretty(&slot).expect("serialise");
+        std::fs::write(&path, &text).expect("write");
+
+        let loaded: PresetSlot =
+            toml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("deserialise");
+
+        assert!(loaded.mute_btn_disabled, "mute_btn_disabled must survive a file roundtrip");
+        assert_eq!(loaded.tone, 5, "tone must survive a file roundtrip");
+        assert!(loaded.denoiser_enabled, "denoiser_enabled must survive a file roundtrip");
+        assert!(
+            loaded.popper_stopper_enabled,
+            "popper_stopper_enabled must survive a file roundtrip"
+        );
+    }
+
+    #[test]
+    fn summary_mv6_shows_denoiser_popper_tone_hpf_not_phantom_eq_comp() {
+        let mut state = mv6_example_state();
+        state.denoiser_enabled = true;
+        state.popper_stopper_enabled = false;
+        state.tone = 5; // +50% Bright
+        state.hpf = HpfFrequency::Hz75;
+        let slot = PresetSlot::from_device_state("S", &state);
+        let s = slot.summary(DeviceModel::Mv6);
+        assert!(s.contains("24dB"), "summary: {s}");
+        assert!(s.contains("Denoiser on"), "summary: {s}");
+        assert!(s.contains("Popper off"), "summary: {s}");
+        assert!(s.contains("HPF 75 Hz"), "summary: {s}");
+        assert!(s.contains("50% Bright"), "summary: {s}");
+        // MVX2U-specific fields must not appear
+        assert!(!s.contains("48V"), "MV6 summary must not mention phantom: {s}");
+        assert!(!s.contains("EQ"), "MV6 summary must not mention EQ: {s}");
+        assert!(!s.contains("Comp"), "MV6 summary must not mention Comp: {s}");
+    }
+
+    #[test]
+    fn summary_mv6_tone_natural_and_dark() {
+        let mut state = mv6_example_state();
+        state.tone = 0;
+        let slot = PresetSlot::from_device_state("S", &state);
+        assert!(slot.summary(DeviceModel::Mv6).contains("Natural"), "zero tone should be Natural");
+
+        let mut state2 = mv6_example_state();
+        state2.tone = -3; // -30% Dark
+        let slot2 = PresetSlot::from_device_state("S", &state2);
+        assert!(slot2.summary(DeviceModel::Mv6).contains("30% Dark"), "negative tone should be Dark");
     }
 }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -564,13 +564,27 @@ mod tests {
         }
     }
 
+    /// Serialise `slot` to TOML and deserialise it again, returning the decoded copy.
+    fn toml_roundtrip(slot: &PresetSlot) -> PresetSlot {
+        let toml_str = toml::to_string_pretty(slot).expect("serialise");
+        toml::from_str(&toml_str).expect("deserialise")
+    }
+
+    /// Write `slot` to a temp file and reload it, returning the loaded copy.
+    fn write_and_reload(slot: &PresetSlot) -> PresetSlot {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("preset_1.toml");
+        let text = toml::to_string_pretty(slot).expect("serialise");
+        std::fs::write(&path, &text).expect("write");
+        toml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("deserialise")
+    }
+
     #[test]
     fn preset_slot_roundtrip_toml() {
         let state = example_state();
         let slot = PresetSlot::from_device_state("My Preset", &state);
 
-        let toml_str = toml::to_string_pretty(&slot).expect("serialise");
-        let decoded: PresetSlot = toml::from_str(&toml_str).expect("deserialise");
+        let decoded = toml_roundtrip(&slot);
 
         assert_eq!(slot, decoded);
         assert_eq!(decoded.name, "My Preset");
@@ -619,15 +633,7 @@ mod tests {
         let state = example_state();
         let slot = PresetSlot::from_device_state("Roundtrip", &state);
 
-        // Use a temp dir so tests are hermetic.
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("preset_1.toml");
-
-        let text = toml::to_string_pretty(&slot).expect("serialise");
-        std::fs::write(&path, &text).expect("write");
-
-        let loaded: PresetSlot =
-            toml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("deserialise");
+        let loaded = write_and_reload(&slot);
 
         assert_eq!(slot, loaded);
     }
@@ -703,8 +709,7 @@ mod tests {
         let state = mv6_example_state();
         let slot = PresetSlot::from_device_state("MV6 Preset", &state);
 
-        let toml_str = toml::to_string_pretty(&slot).expect("serialise");
-        let decoded: PresetSlot = toml::from_str(&toml_str).expect("deserialise");
+        let decoded = toml_roundtrip(&slot);
 
         assert_eq!(slot, decoded);
         assert_eq!(decoded.name, "MV6 Preset");
@@ -756,14 +761,7 @@ mod tests {
         let state = mv6_example_state(); // mute_btn_disabled = true
         let slot = PresetSlot::from_device_state("MV6 File", &state);
 
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("preset_1.toml");
-
-        let text = toml::to_string_pretty(&slot).expect("serialise");
-        std::fs::write(&path, &text).expect("write");
-
-        let loaded: PresetSlot =
-            toml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("deserialise");
+        let loaded = write_and_reload(&slot);
 
         assert!(
             loaded.mute_btn_disabled,

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -160,7 +160,11 @@ impl PresetSlot {
                 )
             }
             DeviceModel::Mvx2u => {
-                let phantom_str = if self.phantom_power { "48V on" } else { "48V off" };
+                let phantom_str = if self.phantom_power {
+                    "48V on"
+                } else {
+                    "48V off"
+                };
                 match InputMode::from(self.mode) {
                     InputMode::Auto => {
                         let tone = AutoTone::from(self.auto_tone);
@@ -219,7 +223,8 @@ pub fn load_preset(index: usize) -> Result<Option<PresetSlot>> {
         Ok(t) => t,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(e) => {
-            return Err(e).with_context(|| format!("Failed to read preset file: {}", path.display()))
+            return Err(e)
+                .with_context(|| format!("Failed to read preset file: {}", path.display()));
         }
     };
     let slot: PresetSlot = toml::from_str(&text)
@@ -528,11 +533,26 @@ mod tests {
             hpf: HpfFrequency::Hz75,
             eq_enabled: true,
             eq_bands: [
-                EqBand { enabled: true, gain_db: 4 },
-                EqBand { enabled: false, gain_db: -2 },
-                EqBand { enabled: true, gain_db: 0 },
-                EqBand { enabled: false, gain_db: 6 },
-                EqBand { enabled: true, gain_db: -8 },
+                EqBand {
+                    enabled: true,
+                    gain_db: 4,
+                },
+                EqBand {
+                    enabled: false,
+                    gain_db: -2,
+                },
+                EqBand {
+                    enabled: true,
+                    gain_db: 0,
+                },
+                EqBand {
+                    enabled: false,
+                    gain_db: 6,
+                },
+                EqBand {
+                    enabled: true,
+                    gain_db: -8,
+                },
             ],
             locked: false,
             denoiser_enabled: true,
@@ -745,9 +765,15 @@ mod tests {
         let loaded: PresetSlot =
             toml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("deserialise");
 
-        assert!(loaded.mute_btn_disabled, "mute_btn_disabled must survive a file roundtrip");
+        assert!(
+            loaded.mute_btn_disabled,
+            "mute_btn_disabled must survive a file roundtrip"
+        );
         assert_eq!(loaded.tone, 5, "tone must survive a file roundtrip");
-        assert!(loaded.denoiser_enabled, "denoiser_enabled must survive a file roundtrip");
+        assert!(
+            loaded.denoiser_enabled,
+            "denoiser_enabled must survive a file roundtrip"
+        );
         assert!(
             loaded.popper_stopper_enabled,
             "popper_stopper_enabled must survive a file roundtrip"
@@ -769,9 +795,15 @@ mod tests {
         assert!(s.contains("HPF 75 Hz"), "summary: {s}");
         assert!(s.contains("50% Bright"), "summary: {s}");
         // MVX2U-specific fields must not appear
-        assert!(!s.contains("48V"), "MV6 summary must not mention phantom: {s}");
+        assert!(
+            !s.contains("48V"),
+            "MV6 summary must not mention phantom: {s}"
+        );
         assert!(!s.contains("EQ"), "MV6 summary must not mention EQ: {s}");
-        assert!(!s.contains("Comp"), "MV6 summary must not mention Comp: {s}");
+        assert!(
+            !s.contains("Comp"),
+            "MV6 summary must not mention Comp: {s}"
+        );
     }
 
     #[test]
@@ -779,11 +811,17 @@ mod tests {
         let mut state = mv6_example_state();
         state.tone = 0;
         let slot = PresetSlot::from_device_state("S", &state);
-        assert!(slot.summary(DeviceModel::Mv6).contains("Natural"), "zero tone should be Natural");
+        assert!(
+            slot.summary(DeviceModel::Mv6).contains("Natural"),
+            "zero tone should be Natural"
+        );
 
         let mut state2 = mv6_example_state();
         state2.tone = -3; // -30% Dark
         let slot2 = PresetSlot::from_device_state("S", &state2);
-        assert!(slot2.summary(DeviceModel::Mv6).contains("30% Dark"), "negative tone should be Dark");
+        assert!(
+            slot2.summary(DeviceModel::Mv6).contains("30% Dark"),
+            "negative tone should be Dark"
+        );
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,7 +1,11 @@
-//! MVX2U USB HID Protocol Implementation
+//! Shure USB HID Protocol Implementation
 //!
-//! The MVX2U uses USB HID reports for configuration, communicated via
-//! `write()` (host→device) and `read()` (device→host) on the hidraw fd.
+//! Covers two devices:
+//!   - Shure MVX2U  (VID 0x14ED, PID 0x1013) — XLR-to-USB interface
+//!   - Shure MV6    (VID 0x14ED, PID 0x1026) — USB gaming microphone
+//!
+//! Both devices use the same packet framing, CRC algorithm, and command
+//! class structure. Feature addresses differ between models.
 //!
 //! Packet structure (64 bytes total, written via hidapi):
 //!
@@ -24,15 +28,16 @@
 //! USB IDs:
 //!   Vendor ID:  0x14ED  (Shure)
 //!   Product ID: 0x1013  (MVX2U)
+//!   Product ID: 0x1026  (MV6)
 //!
 //! Every SET command must be followed by a CONFIRM packet (CMD_CONFIRM).
 //! GET commands receive a response on the next `read()`.
 //!
-//! Feature addresses (2 bytes):
+//! ── MVX2U Feature addresses (2 bytes) ────────────────────────────────────────
 //!   Config lock:    [0x00, 0xA6]  — 1 byte: 0=unlocked, 1=locked
 //!                                   Uses CMD_GET_LOCK / CMD_SET_LOCK (last byte 0x01, not 0x02)
 //!                                   Payload prefix byte is 0x06 (not 0x00 or 0x01)
-//!   Gain (manual):  [0x01, 0x02]  — 16-bit big-endian, units: gain_db * 100
+//!   Gain (manual):  [0x01, 0x02]  — 16-bit big-endian, units: gain_db * 100, range 0–60 dB
 //!   Mute:           [0x01, 0x04]  — 1 byte: 0=unmuted, 1=muted
 //!   HPF:            [0x01, 0x06]  — 1 byte: 0=off, 1=75Hz, 2=150Hz
 //!   Limiter:        [0x01, 0x51]  — 1 byte: 0=off, 1=on
@@ -50,9 +55,64 @@
 //!
 //! EQ bands have fixed center frequencies: 100, 250, 1000, 4000, 10000 Hz.
 //! Frequency and Q are not adjustable on this device.
+//!
+//! ── MV6 Feature addresses (2 bytes) ──────────────────────────────────────────
+//! All confirmed by GET probe against firmware 1.3.0.6 unless noted.
+//!
+//!   Gain (manual):   [0x01, 0x02]  — 16-bit big-endian, units: gain_db * 100, max 36 dB
+//!                    SET confirmed working and persists to flash across replug (probe-verified).
+//!                    MOTIV on macOS does not re-read gain on reconnect — it restores from its
+//!                    own cache instead. Other settings (HPF, denoiser, etc.) do refresh. This
+//!                    is a Shure app bug; shurectl SET behaviour is correct.
+//!   Mute:            [0x01, 0x04]  — 1 byte: 0=unmuted, 1=muted
+//!   HPF:             [0x01, 0x06]  — 1 byte: 0=off, 1=75Hz, 2=150Hz
+//!   Denoiser:        [0x01, 0x58]  — 1 byte: 0=off, 1=on  (GET-readable, confirmed)
+//!   Auto level:      [0x01, 0x85]  — 1 byte: 0=manual, 1=auto
+//!   Popper stopper:  [0x03, 0x81]  — 1 byte: 0=off, 1=on  (confirmed by MOTIV app probe diff)
+//!   Mute btn disable:[0x0C, 0x00]  — SET uses cmd [02 02 01], HDR_CONSTANT=0x00,
+//!                                    payload [addr_hi, addr_lo, 0x60, enable_byte].
+//!                                    enable_byte: 0x00=disabled, 0x01=active (inverted).
+//!                                    State persisted host-side; GET unreliable.
+//!   Gain lock:       [0x01, 0xF3]  — 1 byte: 0=unlocked, 1=locked (Manual mode only)
+//!                                    Confirmed by probe diff: value changed 0x00→0x01 when
+//!                                    gain lock was enabled in MOTIV Mix. Standard CMD_GET_FEAT
+//!                                    / CMD_SET_FEAT, prefix 0x00. SET encoding unverified —
+//!                                    verify with usbmon if toggling does not take effect.
+//!   Tone:            [0x02, 0x04]  — 16-bit signed big-endian, units: percent
+//!                                    Range: -100 (Dark) to +100 (Bright), steps of 10.
+//!                                    0 = Natural (confirmed at factory default).
 
 pub const VID: u16 = 0x14ED;
+/// MVX2U: XLR-to-USB audio interface.
 pub const PID: u16 = 0x1013;
+/// MV6: USB gaming microphone.
+pub const MV6_PID: u16 = 0x1026;
+
+/// Which Shure device model is connected. Drives capability decisions
+/// throughout the app (which controls to show, gain max, etc.).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DeviceModel {
+    Mvx2u,
+    Mv6,
+}
+
+impl DeviceModel {
+    /// Maximum manual gain in dB for this device.
+    pub fn max_gain_db(&self) -> u8 {
+        match self {
+            DeviceModel::Mvx2u => 60,
+            DeviceModel::Mv6 => 36,
+        }
+    }
+
+    /// Human-readable model name for display.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            DeviceModel::Mvx2u => "Shure MVX2U",
+            DeviceModel::Mv6 => "Shure MV6",
+        }
+    }
+}
 pub const PACKET_SIZE: usize = 64;
 
 // Fixed header bytes
@@ -111,35 +171,79 @@ const EQ_BAND_ADDRS: [([u8; 2], [u8; 2]); 5] = [
 /// The center frequency (Hz) for each of the 5 EQ bands. Fixed by hardware.
 pub const EQ_BAND_FREQS: [u16; 5] = [100, 250, 1000, 4000, 10000];
 
+// ── MV6-specific feature addresses ───────────────────────────────────────────
+//
+// Confirmed by GET probe against MV6 firmware 1.3.0.6.
+// Gain, Mute, HPF, and Auto Level share addresses with the MVX2U.
+
+/// MV6 real-time denoiser. 0=off, 1=on. GET-readable and writable.
+const MV6_FEAT_DENOISER: [u8; 2] = [0x01, 0x58];
+/// MV6 popper stopper. 0=off, 1=on. Confirmed by MOTIV app probe diff — toggling
+/// popper stopper in MOTIV changes this address between [00] and [01].
+const MV6_FEAT_POPPER_STOPPER: [u8; 2] = [0x03, 0x81];
+/// MV6 mute button disable. Address [0x0C, 0x00] confirmed by Wireshark capture.
+/// SET uses cmd [02 02 01], HDR_CONSTANT=0x00, inverted encoding (0x00=disabled, 0x01=active).
+/// State is persisted host-side in mv6_state.toml since GET is unreliable.
+const MV6_FEAT_MUTE_BTN_DISABLE: [u8; 2] = [0x0C, 0x00];
+/// MV6 tone character. 16-bit signed big-endian, units: percent.
+/// Range: -100 (Dark) to +100 (Bright) in steps of 10. 0 = Natural (default).
+const MV6_FEAT_TONE: [u8; 2] = [0x02, 0x04];
+/// MV6 gain lock (Manual mode only). 0=unlocked, 1=locked.
+/// Confirmed by probe diff against MOTIV Mix with gain lock on/off.
+/// SET encoding assumed standard CMD_SET_FEAT / prefix 0x00 — verify with usbmon if misbehaving.
+const MV6_FEAT_GAIN_LOCK: [u8; 2] = [0x01, 0xF3];
 // ── Phantom power value encoding ──────────────────────────────────────────────
 const PHANTOM_ON: u8 = 0x30; // 48 decimal = 48V
 const PHANTOM_OFF: u8 = 0x00;
 
 // ── Device state (fully decoded) ──────────────────────────────────────────────
+//
+// Fields used only by one model are noted inline. Unused fields for a given
+// model remain at their default values and are not sent to the device.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeviceState {
-    /// Manual gain in dB, range 0–60.
-    /// Defaults to 36 dB, which matches the MVX2U factory default.
+    /// Manual gain in dB. MVX2U range: 0–60. MV6 range: 0–36.
+    /// Defaults to 36 dB (MVX2U factory default; also MV6 maximum).
     pub gain_db: u8,
     pub mode: InputMode,
-    /// Mic position for Auto Level mode.
+    /// Mic position for Auto Level mode. MVX2U only.
     pub auto_position: MicPosition,
-    /// Tone preset for Auto Level mode.
+    /// Tone preset for Auto Level mode. MVX2U only.
     pub auto_tone: AutoTone,
-    /// Gain preset for Auto Level mode.
+    /// Gain preset for Auto Level mode. MVX2U only.
     pub auto_gain: AutoGain,
     pub muted: bool,
+    /// 48V phantom power. MVX2U only (XLR input).
     pub phantom_power: bool,
-    /// Monitor mix: 0 = 100% mic, 100 = 100% playback.
+    /// Monitor mix: 0 = 100% mic, 100 = 100% playback. MVX2U only.
     pub monitor_mix: u8,
+    /// Limiter. MVX2U only.
     pub limiter_enabled: bool,
+    /// Compressor preset. MVX2U only.
     pub compressor: CompressorPreset,
     pub hpf: HpfFrequency,
+    /// 5-band parametric EQ master enable. MVX2U only.
     pub eq_enabled: bool,
-    /// 5 EQ bands at fixed frequencies (100, 250, 1k, 4k, 10k Hz).
+    /// 5 EQ bands at fixed frequencies (100, 250, 1k, 4k, 10k Hz). MVX2U only.
     pub eq_bands: [EqBand; 5],
-    /// Whether the device configuration is locked against changes.
+    /// Config lock (ignores SET commands while locked). MVX2U only.
     pub locked: bool,
+
+    // ── MV6-specific fields ───────────────────────────────────────────────────
+    /// Real-time denoiser. MV6 only.
+    pub denoiser_enabled: bool,
+    /// Popper stopper. MV6 only. Address [0x03, 0x81] confirmed by MOTIV app probe diff.
+    pub popper_stopper_enabled: bool,
+    /// Mute button disable. MV6 only. Address [0x0C, 0x00] confirmed by Wireshark capture.
+    /// State persisted host-side in mv6_state.toml; see presets::Mv6State.
+    pub mute_btn_disabled: bool,
+    /// Tone character. MV6 only. Range: -10 to +10 (displayed as × 10%).
+    /// -10 = 100% Dark, 0 = Natural, +10 = 100% Bright.
+    pub tone: i8,
+    /// Gain lock (Manual mode only). MV6 only. Prevents gain from being changed
+    /// while locked. Address [0x01, 0xF3] confirmed by probe diff.
+    pub mv6_gain_locked: bool,
+
     /// Device serial number string, populated after connection.
     pub serial_number: String,
 }
@@ -161,6 +265,12 @@ impl Default for DeviceState {
             eq_enabled: false,
             eq_bands: [EqBand::default(); 5],
             locked: false,
+            // MV6 defaults match factory reset state observed in MOTIV app.
+            denoiser_enabled: false,
+            popper_stopper_enabled: true,
+            mute_btn_disabled: false,
+            tone: 0, // Natural
+            mv6_gain_locked: false,
             serial_number: String::from("Unknown"),
         }
     }
@@ -618,6 +728,21 @@ pub fn cmd_get_eq_enable(seq: u8) -> Vec<u8> {
     cmd_get(seq, &FEAT_EQ)
 }
 
+// ── MV6 GET constructors ──────────────────────────────────────────────────────
+
+pub fn cmd_get_mv6_denoiser(seq: u8) -> Vec<u8> {
+    cmd_get(seq, &MV6_FEAT_DENOISER)
+}
+pub fn cmd_get_mv6_popper_stopper(seq: u8) -> Vec<u8> {
+    cmd_get(seq, &MV6_FEAT_POPPER_STOPPER)
+}
+pub fn cmd_get_mv6_tone(seq: u8) -> Vec<u8> {
+    cmd_get(seq, &MV6_FEAT_TONE)
+}
+pub fn cmd_get_mv6_gain_lock(seq: u8) -> Vec<u8> {
+    cmd_get(seq, &MV6_FEAT_GAIN_LOCK)
+}
+
 // ── Lock command constructors ─────────────────────────────────────────────────
 //
 // Lock uses a distinct command type (CMD_GET_LOCK / CMD_SET_LOCK) and a
@@ -641,14 +766,14 @@ pub fn cmd_set_lock(seq: u8, locked: bool) -> Vec<u8> {
 }
 
 pub fn cmd_get_eq_band_enable(seq: u8, band: usize) -> Vec<u8> {
-    debug_assert!(
+    assert!(
         band < EQ_BAND_ADDRS.len(),
         "band index out of range: {band}"
     );
     cmd_get(seq, &EQ_BAND_ADDRS[band].0)
 }
 pub fn cmd_get_eq_band_gain(seq: u8, band: usize) -> Vec<u8> {
-    debug_assert!(
+    assert!(
         band < EQ_BAND_ADDRS.len(),
         "band index out of range: {band}"
     );
@@ -657,10 +782,11 @@ pub fn cmd_get_eq_band_gain(seq: u8, band: usize) -> Vec<u8> {
 
 // ── Public SET constructors ───────────────────────────────────────────────────
 
-/// Set manual gain. `gain_db` is clamped to 0–60.
-/// Encoded as `gain_db * 100` in 16-bit big-endian.
+/// Set manual gain. `gain_db` is the already-clamped value from `device.rs::set_gain`,
+/// which enforces the model-specific ceiling (60 dB MVX2U, 36 dB MV6).
+/// Encoded as `gain_db * 100` in 16-bit big-endian. Shared by both devices.
 pub fn cmd_set_gain(seq: u8, gain_db: u8) -> Vec<u8> {
-    let raw = (gain_db.min(60) as u16) * 100;
+    let raw = gain_db as u16 * 100;
     cmd_set(seq, &FEAT_GAIN, &raw.to_be_bytes())
 }
 
@@ -720,7 +846,7 @@ pub fn cmd_set_eq_enable(seq: u8, enabled: bool) -> Vec<u8> {
 
 /// Set EQ band enable. `band` is 0–4.
 pub fn cmd_set_eq_band_enable(seq: u8, band: usize, enabled: bool) -> Vec<u8> {
-    debug_assert!(
+    assert!(
         band < EQ_BAND_ADDRS.len(),
         "band index out of range: {band}"
     );
@@ -731,13 +857,80 @@ pub fn cmd_set_eq_band_enable(seq: u8, band: usize, enabled: bool) -> Vec<u8> {
 /// nearest even value (hardware supports −8, −6, −4, −2, 0, 2, 4, 6 only).
 /// Encoded as `gain_db * 10` in 16-bit signed big-endian.
 pub fn cmd_set_eq_band_gain(seq: u8, band: usize, gain_db: i8) -> Vec<u8> {
-    debug_assert!(
+    assert!(
         band < EQ_BAND_ADDRS.len(),
         "band index out of range: {band}"
     );
     let clamped = gain_db.clamp(-8, 6);
     let raw = (clamped as i16 * 10).to_be_bytes();
     cmd_set(seq, &EQ_BAND_ADDRS[band].1, &raw)
+}
+
+// ── MV6 SET constructors ──────────────────────────────────────────────────────
+
+/// Enable or disable the MV6 real-time denoiser.
+pub fn cmd_set_mv6_denoiser(seq: u8, enabled: bool) -> Vec<u8> {
+    cmd_set(seq, &MV6_FEAT_DENOISER, &[u8::from(enabled)])
+}
+
+/// Enable or disable the MV6 popper stopper.
+pub fn cmd_set_mv6_popper_stopper(seq: u8, enabled: bool) -> Vec<u8> {
+    cmd_set(seq, &MV6_FEAT_POPPER_STOPPER, &[u8::from(enabled)])
+}
+
+/// Enable or disable the MV6 mute button.
+/// `disabled = true` disables the physical mute button on the device.
+///
+/// Quirks confirmed by Wireshark capture against MOTIV app:
+///   - cmd bytes are [0x02, 0x02, 0x01] (CMD_SET_LOCK class, not CMD_SET_FEAT)
+///   - HDR_CONSTANT is 0x00 (not the usual 0x03)
+///   - no is_mix prefix — payload is [addr_hi, addr_lo, 0x60, enable_byte]
+///   - value encoding is inverted: 0x00=button disabled, 0x01=button active
+pub fn cmd_set_mv6_mute_btn_disable(seq: u8, disabled: bool) -> Vec<u8> {
+    let enable_byte: u8 = if disabled { 0x00 } else { 0x01 };
+    let mix_byte: u8 = 0x60;
+    let payload = [MV6_FEAT_MUTE_BTN_DISABLE[0], MV6_FEAT_MUTE_BTN_DISABLE[1], mix_byte, enable_byte];
+    let data_len = (3 + payload.len() + 2) as u8;
+
+    let mut inner: Vec<u8> = Vec::with_capacity(PACKET_SIZE);
+    inner.push(HEADER_MAGIC[0]);
+    inner.push(HEADER_MAGIC[1]);
+    inner.push(seq);
+    inner.push(0x00); // HDR_CONSTANT: 0x00 for this command (not the usual 0x03)
+    inner.push(HDR_END);
+    inner.push(data_len);
+    inner.push(DATA_START);
+    inner.push(data_len);
+    inner.extend_from_slice(&CMD_SET_LOCK); // [02 02 01], not CMD_SET_FEAT [02 02 02]
+    inner.extend_from_slice(&payload);
+
+    let total_len = (inner.len() + 2) as u8;
+    let crc = crc16_ansi(&inner);
+
+    let mut pkt: Vec<u8> = Vec::with_capacity(PACKET_SIZE);
+    pkt.push(REPORT_ID);
+    pkt.push(total_len);
+    pkt.extend_from_slice(&inner);
+    pkt.push((crc >> 8) as u8);
+    pkt.push((crc & 0xFF) as u8);
+    pkt.resize(PACKET_SIZE, 0x00);
+    pkt
+}
+
+/// Set the MV6 tone character.
+/// `tone` is clamped to −10..+10 and encoded as `tone * 10` in 16-bit signed big-endian.
+/// -10 = 100% Dark, 0 = Natural, +10 = 100% Bright.
+pub fn cmd_set_mv6_tone(seq: u8, tone: i8) -> Vec<u8> {
+    let clamped = tone.clamp(-10, 10);
+    let raw = (clamped as i16 * 10).to_be_bytes();
+    cmd_set(seq, &MV6_FEAT_TONE, &raw)
+}
+
+/// Lock or unlock the MV6 gain in Manual mode.
+/// `locked = true` prevents gain changes; `false` allows them.
+/// Must be followed by a CONFIRM packet (handled by `send_set`).
+pub fn cmd_set_mv6_gain_lock(seq: u8, locked: bool) -> Vec<u8> {
+    cmd_set(seq, &MV6_FEAT_GAIN_LOCK, &[u8::from(locked)])
 }
 
 // ── Response decoder ──────────────────────────────────────────────────────────
@@ -760,7 +953,9 @@ pub fn apply_response(feat_addr: [u8; 2], value: &[u8], state: &mut DeviceState)
                 return false;
             }
             let raw = u16::from_be_bytes([value[0], value[1]]);
-            state.gain_db = (raw / 100).min(60) as u8;
+            // No model-specific clamp here — apply_response is model-agnostic.
+            // The adjustment layer (adjust_focused) enforces device_model.max_gain_db().
+            state.gain_db = (raw / 100) as u8;
             true
         }
         f if f == FEAT_MUTE => {
@@ -842,6 +1037,44 @@ pub fn apply_response(feat_addr: [u8; 2], value: &[u8], state: &mut DeviceState)
                 return false;
             }
             state.eq_enabled = value[0] != 0;
+            true
+        }
+        // ── MV6-specific features ─────────────────────────────────────────────
+        f if f == MV6_FEAT_DENOISER => {
+            if value.is_empty() {
+                return false;
+            }
+            state.denoiser_enabled = value[0] != 0;
+            true
+        }
+        f if f == MV6_FEAT_POPPER_STOPPER => {
+            if value.is_empty() {
+                return false;
+            }
+            state.popper_stopper_enabled = value[0] != 0;
+            true
+        }
+        f if f == MV6_FEAT_MUTE_BTN_DISABLE => {
+            if value.is_empty() {
+                return false;
+            }
+            state.mute_btn_disabled = value[0] != 0;
+            true
+        }
+        f if f == MV6_FEAT_TONE => {
+            if value.len() < 2 {
+                return false;
+            }
+            let raw = i16::from_be_bytes([value[0], value[1]]);
+            // Clamp and round to step: divide by 10, clamp to -10..+10.
+            state.tone = (raw / 10).clamp(-10, 10) as i8;
+            true
+        }
+        f if f == MV6_FEAT_GAIN_LOCK => {
+            if value.is_empty() {
+                return false;
+            }
+            state.mv6_gain_locked = value[0] != 0;
             true
         }
         _ => {
@@ -1009,13 +1242,6 @@ mod tests {
         // value at pkt[16..18]
         let raw = u16::from_be_bytes([pkt[16], pkt[17]]);
         assert_eq!(raw, 3600, "36 dB must encode as 3600");
-    }
-
-    #[test]
-    fn set_gain_clamps_at_60() {
-        let pkt = cmd_set_gain(0, 200);
-        let raw = u16::from_be_bytes([pkt[16], pkt[17]]);
-        assert_eq!(raw, 6000, "gain clamped to 60 dB = raw 6000");
     }
 
     #[test]
@@ -1298,11 +1524,12 @@ mod tests {
     }
 
     #[test]
-    fn apply_response_gain_clamps_at_60() {
+    fn apply_response_gain_no_clamp() {
         let mut state = DeviceState::default();
-        // raw 9000 / 100 = 90 dB, must clamp to 60
+        // apply_response is model-agnostic — it does not clamp to any model's max.
+        // raw 9000 / 100 = 90; the model-specific ceiling is enforced in adjust_focused.
         let _ = apply_response(FEAT_GAIN, &[0x23, 0x28], &mut state);
-        assert_eq!(state.gain_db, 60);
+        assert_eq!(state.gain_db, 90);
     }
 
     #[test]
@@ -1783,5 +2010,186 @@ mod tests {
         for w in seq.windows(2) {
             assert_eq!(w[0].cycle_next(), w[1]);
         }
+    }
+
+    // ── MV6 protocol tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn mv6_denoiser_packet_roundtrip() {
+        for (enabled, expected_byte) in [(false, 0x00u8), (true, 0x01u8)] {
+            let pkt = cmd_set_mv6_denoiser(0, enabled);
+            assert_eq!(pkt.len(), PACKET_SIZE);
+            assert_eq!(&pkt[14..16], &MV6_FEAT_DENOISER, "feature address mismatch");
+            assert_eq!(pkt[16], expected_byte);
+        }
+    }
+
+    #[test]
+    fn mv6_denoiser_apply_response_roundtrip() {
+        for (bytes, expected) in [(&[0x00u8][..], false), (&[0x01u8][..], true)] {
+            let mut state = DeviceState::default();
+            assert!(apply_response(MV6_FEAT_DENOISER, bytes, &mut state));
+            assert_eq!(state.denoiser_enabled, expected);
+        }
+    }
+
+    #[test]
+    fn mv6_denoiser_apply_response_empty_returns_false() {
+        let mut state = DeviceState::default();
+        assert!(!apply_response(MV6_FEAT_DENOISER, &[], &mut state));
+    }
+
+    #[test]
+    fn mv6_tone_packet_roundtrip() {
+        for (tone, expected_raw) in [(-10i8, -100i16), (0, 0), (10, 100)] {
+            let pkt = cmd_set_mv6_tone(0, tone);
+            assert_eq!(pkt.len(), PACKET_SIZE);
+            assert_eq!(&pkt[14..16], &MV6_FEAT_TONE, "feature address mismatch");
+            let encoded = i16::from_be_bytes([pkt[16], pkt[17]]);
+            assert_eq!(encoded, expected_raw, "tone encoding mismatch for {tone}");
+        }
+    }
+
+    #[test]
+    fn mv6_tone_clamps_to_range() {
+        // Values outside -10..+10 must be clamped before encoding.
+        let pkt_low = cmd_set_mv6_tone(0, -99);
+        let encoded_low = i16::from_be_bytes([pkt_low[16], pkt_low[17]]);
+        assert_eq!(encoded_low, -100, "clamped to -10 * 10");
+
+        let pkt_high = cmd_set_mv6_tone(0, 99);
+        let encoded_high = i16::from_be_bytes([pkt_high[16], pkt_high[17]]);
+        assert_eq!(encoded_high, 100, "clamped to +10 * 10");
+    }
+
+    #[test]
+    fn mv6_tone_apply_response_roundtrip() {
+        let cases: &[(&[u8], i8)] = &[
+            (&[0xFF, 0x9C], -10), // -100 / 10 = -10
+            (&[0x00, 0x00], 0),   // 0 = Natural
+            (&[0x00, 0x64], 10),  // +100 / 10 = +10
+        ];
+        for (bytes, expected) in cases {
+            let mut state = DeviceState::default();
+            assert!(apply_response(MV6_FEAT_TONE, bytes, &mut state));
+            assert_eq!(state.tone, *expected);
+        }
+    }
+
+    #[test]
+    fn mv6_tone_apply_response_short_returns_false() {
+        let mut state = DeviceState::default();
+        assert!(!apply_response(MV6_FEAT_TONE, &[0x00], &mut state));
+    }
+
+    #[test]
+    fn mv6_popper_stopper_packet_has_correct_address() {
+        let pkt = cmd_set_mv6_popper_stopper(0, true);
+        assert_eq!(pkt.len(), PACKET_SIZE);
+        // Address confirmed by MOTIV app probe diff: [03 81] toggles with popper stopper.
+        assert_eq!(&pkt[14..16], &[0x03u8, 0x81]);
+        assert_eq!(pkt[16], 0x01);
+    }
+
+    #[test]
+    fn mv6_popper_stopper_apply_response_roundtrip() {
+        for (bytes, expected) in [(&[0x00u8][..], false), (&[0x01u8][..], true)] {
+            let mut state = DeviceState::default();
+            assert!(apply_response(MV6_FEAT_POPPER_STOPPER, bytes, &mut state));
+            assert_eq!(state.popper_stopper_enabled, expected);
+        }
+    }
+
+    #[test]
+    fn mv6_popper_stopper_apply_response_empty_returns_false() {
+        let mut state = DeviceState::default();
+        assert!(!apply_response(MV6_FEAT_POPPER_STOPPER, &[], &mut state));
+    }
+
+    #[test]
+    fn mv6_mute_btn_disable_packet_has_correct_address() {
+        // SET confirmed by Wireshark: cmd=[02 02 01], HDR_CONSTANT=0x00,
+        // inverted encoding (0x00=disabled, 0x01=active).
+        let pkt_on = cmd_set_mv6_mute_btn_disable(0, true);
+        assert_eq!(pkt_on.len(), PACKET_SIZE);
+        assert_eq!(pkt_on[5], 0x00, "HDR_CONSTANT must be 0x00");
+        assert_eq!(&pkt_on[10..13], &[0x02u8, 0x02, 0x01], "cmd must be [02 02 01]");
+        assert_eq!(&pkt_on[13..15], &MV6_FEAT_MUTE_BTN_DISABLE);
+        assert_eq!(pkt_on[15], 0x60, "mix_byte must be 0x60");
+        assert_eq!(pkt_on[16], 0x00, "disabled=true encodes as 0x00");
+
+        let pkt_off = cmd_set_mv6_mute_btn_disable(0, false);
+        assert_eq!(pkt_off[16], 0x01, "disabled=false encodes as 0x01");
+    }
+
+    #[test]
+    fn mv6_mute_btn_disable_apply_response_roundtrip() {
+        for (bytes, expected) in [(&[0x00u8][..], false), (&[0x01u8][..], true)] {
+            let mut state = DeviceState::default();
+            assert!(apply_response(MV6_FEAT_MUTE_BTN_DISABLE, bytes, &mut state));
+            assert_eq!(state.mute_btn_disabled, expected);
+        }
+    }
+
+    #[test]
+    fn mv6_mute_btn_disable_apply_response_empty_returns_false() {
+        let mut state = DeviceState::default();
+        assert!(!apply_response(MV6_FEAT_MUTE_BTN_DISABLE, &[], &mut state));
+    }
+
+    #[test]
+    fn device_model_max_gain_db() {
+        assert_eq!(DeviceModel::Mvx2u.max_gain_db(), 60);
+        assert_eq!(DeviceModel::Mv6.max_gain_db(), 36);
+    }
+
+    // ── MV6 gain lock ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn mv6_gain_lock_get_packet_structure() {
+        let pkt = cmd_get_mv6_gain_lock(0);
+        assert_eq!(pkt.len(), PACKET_SIZE);
+        assert_eq!(&pkt[10..13], &CMD_GET_FEAT, "must use CMD_GET_FEAT");
+        assert_eq!(pkt[13], 0x00, "standard prefix must be 0x00");
+        assert_eq!(&pkt[14..16], &MV6_FEAT_GAIN_LOCK);
+    }
+
+    #[test]
+    fn mv6_gain_lock_set_packet_encodes_value() {
+        let pkt_lock = cmd_set_mv6_gain_lock(0, true);
+        assert_eq!(pkt_lock.len(), PACKET_SIZE);
+        assert_eq!(&pkt_lock[10..13], &CMD_SET_FEAT, "must use CMD_SET_FEAT");
+        assert_eq!(pkt_lock[13], 0x00, "standard prefix must be 0x00");
+        assert_eq!(&pkt_lock[14..16], &MV6_FEAT_GAIN_LOCK);
+        assert_eq!(pkt_lock[16], 0x01, "locked=true must encode as 0x01");
+
+        let pkt_unlock = cmd_set_mv6_gain_lock(0, false);
+        assert_eq!(pkt_unlock[16], 0x00, "locked=false must encode as 0x00");
+    }
+
+    #[test]
+    fn mv6_gain_lock_set_packet_has_valid_crc() {
+        for locked in [true, false] {
+            let pkt = cmd_set_mv6_gain_lock(0, locked);
+            let total_len = pkt[1] as usize;
+            let stored_crc = ((pkt[total_len] as u16) << 8) | pkt[total_len + 1] as u16;
+            let computed_crc = crc16_ansi(&pkt[2..total_len]);
+            assert_eq!(stored_crc, computed_crc, "CRC must be valid for locked={locked}");
+        }
+    }
+
+    #[test]
+    fn mv6_gain_lock_apply_response_roundtrip() {
+        for (bytes, expected) in [(&[0x00u8][..], false), (&[0x01u8][..], true)] {
+            let mut state = DeviceState::default();
+            assert!(apply_response(MV6_FEAT_GAIN_LOCK, bytes, &mut state));
+            assert_eq!(state.mv6_gain_locked, expected);
+        }
+    }
+
+    #[test]
+    fn mv6_gain_lock_apply_response_empty_returns_false() {
+        let mut state = DeviceState::default();
+        assert!(!apply_response(MV6_FEAT_GAIN_LOCK, &[], &mut state));
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -889,7 +889,12 @@ pub fn cmd_set_mv6_popper_stopper(seq: u8, enabled: bool) -> Vec<u8> {
 pub fn cmd_set_mv6_mute_btn_disable(seq: u8, disabled: bool) -> Vec<u8> {
     let enable_byte: u8 = if disabled { 0x00 } else { 0x01 };
     let mix_byte: u8 = 0x60;
-    let payload = [MV6_FEAT_MUTE_BTN_DISABLE[0], MV6_FEAT_MUTE_BTN_DISABLE[1], mix_byte, enable_byte];
+    let payload = [
+        MV6_FEAT_MUTE_BTN_DISABLE[0],
+        MV6_FEAT_MUTE_BTN_DISABLE[1],
+        mix_byte,
+        enable_byte,
+    ];
     let data_len = (3 + payload.len() + 2) as u8;
 
     let mut inner: Vec<u8> = Vec::with_capacity(PACKET_SIZE);
@@ -2113,7 +2118,11 @@ mod tests {
         let pkt_on = cmd_set_mv6_mute_btn_disable(0, true);
         assert_eq!(pkt_on.len(), PACKET_SIZE);
         assert_eq!(pkt_on[5], 0x00, "HDR_CONSTANT must be 0x00");
-        assert_eq!(&pkt_on[10..13], &[0x02u8, 0x02, 0x01], "cmd must be [02 02 01]");
+        assert_eq!(
+            &pkt_on[10..13],
+            &[0x02u8, 0x02, 0x01],
+            "cmd must be [02 02 01]"
+        );
         assert_eq!(&pkt_on[13..15], &MV6_FEAT_MUTE_BTN_DISABLE);
         assert_eq!(pkt_on[15], 0x60, "mix_byte must be 0x60");
         assert_eq!(pkt_on[16], 0x00, "disabled=true encodes as 0x00");
@@ -2174,7 +2183,10 @@ mod tests {
             let total_len = pkt[1] as usize;
             let stored_crc = ((pkt[total_len] as u16) << 8) | pkt[total_len + 1] as u16;
             let computed_crc = crc16_ansi(&pkt[2..total_len]);
-            assert_eq!(stored_crc, computed_crc, "CRC must be valid for locked={locked}");
+            assert_eq!(
+                stored_crc, computed_crc,
+                "CRC must be valid for locked={locked}"
+            );
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,8 @@ use ratatui::{
 
 use crate::app::{App, Focus, Tab};
 use crate::protocol::{
-    AutoGain, AutoTone, CompressorPreset, EQ_BAND_FREQS, HpfFrequency, InputMode, MicPosition,
+    AutoGain, AutoTone, CompressorPreset, DeviceModel, EQ_BAND_FREQS, HpfFrequency, InputMode,
+    MicPosition,
 };
 
 // ── Palette ───────────────────────────────────────────────────────────────────
@@ -198,10 +199,123 @@ fn draw_main_tab(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_main_left(f: &mut Frame, app: &App, area: Rect) {
-    match app.device_state.mode {
-        InputMode::Auto => draw_main_left_auto(f, app, area),
-        InputMode::Manual => draw_main_left_manual(f, app, area),
+    match (app.device_model, app.device_state.mode) {
+        (DeviceModel::Mv6, InputMode::Manual) => draw_main_left_mv6_manual(f, app, area),
+        (DeviceModel::Mv6, InputMode::Auto) => draw_main_left_mv6_auto(f, app, area),
+        (DeviceModel::Mvx2u, InputMode::Auto) => draw_main_left_auto(f, app, area),
+        (DeviceModel::Mvx2u, InputMode::Manual) => draw_main_left_manual(f, app, area),
     }
+}
+
+fn draw_main_left_mv6_manual(f: &mut Frame, app: &App, area: Rect) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // mode
+            Constraint::Length(3), // mute
+            Constraint::Length(3), // gain gauge
+            Constraint::Length(3), // gain lock
+            Constraint::Length(4), // level meter
+            Constraint::Min(0),    // spacer
+        ])
+        .margin(1)
+        .split(area);
+
+    draw_mode_block(f, app, rows[0]);
+    draw_mute_block(f, app, rows[1]);
+
+    let gain_focused = app.focus == Focus::Gain;
+    let gain = app.device_state.gain_db;
+    let gain_locked = app.device_state.mv6_gain_locked;
+    let gauge = Gauge::default()
+        .block(
+            Block::default()
+                .title(Line::from(vec![
+                    Span::styled("  GAIN  ", focused_style(gain_focused)),
+                    Span::styled(
+                        format!(" {} dB ", gain),
+                        Style::default().fg(if gain_locked { C_DIM } else { C_ACCENT }).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        if gain_focused && !gain_locked { "  ◄ ► or ←→ to adjust" } else if gain_focused && gain_locked { "  🔒 locked" } else { "" },
+                        Style::default().fg(C_DIM),
+                    ),
+                ]))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(if gain_focused {
+                    Style::default().fg(C_FOCUS)
+                } else {
+                    Style::default().fg(C_BORDER)
+                }),
+        )
+        .gauge_style(Style::default().fg(if gain_locked { C_DISABLED } else { C_ACCENT }).bg(C_SURFACE).add_modifier(
+            if gain_focused { Modifier::BOLD } else { Modifier::empty() },
+        ))
+        .ratio(gain as f64 / app.device_model.max_gain_db() as f64)
+        .label(format!("{gain} / {} dB", app.device_model.max_gain_db()));
+    f.render_widget(gauge, rows[2]);
+
+    // ── Gain Lock ─────────────────────────────────────────────────────────────
+    let lock_focused = app.focus == Focus::GainLock;
+    let lock_icon = if gain_locked { "🔒" } else { "🔓" };
+    let gain_lock_p = Paragraph::new(Line::from(vec![
+        Span::styled(
+            format!("{lock_icon}  Gain Lock:  "),
+            Style::default().fg(C_DIM),
+        ),
+        if gain_locked {
+            Span::styled("LOCKED", Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD))
+        } else {
+            Span::styled("Unlocked", Style::default().fg(C_SUCCESS))
+        },
+        Span::styled(
+            if lock_focused { "  [Enter] toggle" } else { "" },
+            Style::default().fg(C_DIM),
+        ),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if lock_focused {
+                Style::default().fg(C_FOCUS)
+            } else if gain_locked {
+                Style::default().fg(C_ERROR)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .title(Span::styled(
+                "  Gain Lock  ",
+                if lock_focused {
+                    Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+                } else if gain_locked {
+                    Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(C_TEXT)
+                },
+            )),
+    );
+    f.render_widget(gain_lock_p, rows[3]);
+
+    draw_meter(f, app, rows[4]);
+}
+
+fn draw_main_left_mv6_auto(f: &mut Frame, app: &App, area: Rect) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // mode
+            Constraint::Length(3), // mute
+            Constraint::Length(4), // level meter
+            Constraint::Min(0),    // spacer
+        ])
+        .margin(1)
+        .split(area);
+
+    draw_mode_block(f, app, rows[0]);
+    draw_mute_block(f, app, rows[1]);
+    draw_meter(f, app, rows[2]);
 }
 
 fn draw_main_left_manual(f: &mut Frame, app: &App, area: Rect) {
@@ -260,8 +374,8 @@ fn draw_main_left_manual(f: &mut Frame, app: &App, area: Rect) {
                     Modifier::empty()
                 },
             ))
-            .ratio(gain as f64 / 60.0)
-            .label(format!("{gain} / 60 dB"));
+            .ratio(gain as f64 / app.device_model.max_gain_db() as f64)
+            .label(format!("{gain} / {} dB", app.device_model.max_gain_db()));
     f.render_widget(gauge, rows[2]);
 
     draw_main_shared(f, app, &rows[3..]);
@@ -497,7 +611,7 @@ fn draw_mute_block(f: &mut Frame, app: &App, area: Rect) {
 ///
 /// `rows` must have at least 4 elements (indices 0–3).
 fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
-    debug_assert!(
+    assert!(
         rows.len() >= 4,
         "draw_main_shared requires at least 4 row slots, got {}",
         rows.len()
@@ -624,100 +738,170 @@ fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
 fn draw_main_right(f: &mut Frame, app: &App, area: Rect) {
     let ds = &app.device_state;
 
-    // The mode-specific block (gain in Manual, auto sub-settings in Auto)
-    // is inserted between Mode and Muted.
-    let mode_specific_lines: Vec<Line> = match ds.mode {
-        InputMode::Manual => vec![Line::from(vec![
-            Span::styled("Gain        : ", Style::default().fg(C_DIM)),
-            Span::styled(format!("{} dB", ds.gain_db), Style::default().fg(C_TEXT)),
-        ])],
-        InputMode::Auto => vec![
-            Line::from(vec![
-                Span::styled("Position    : ", Style::default().fg(C_DIM)),
-                Span::styled(ds.auto_position.to_string(), Style::default().fg(C_TEXT)),
-            ]),
-            Line::from(vec![
-                Span::styled("Tone        : ", Style::default().fg(C_DIM)),
-                Span::styled(ds.auto_tone.to_string(), Style::default().fg(C_TEXT)),
-            ]),
-            Line::from(vec![
-                Span::styled("Auto Gain   : ", Style::default().fg(C_DIM)),
-                Span::styled(ds.auto_gain.to_string(), Style::default().fg(C_TEXT)),
-            ]),
-        ],
-    };
+    let lines = match app.device_model {
+        DeviceModel::Mvx2u => {
+            let mode_specific_lines: Vec<Line> = match ds.mode {
+                InputMode::Manual => vec![Line::from(vec![
+                    Span::styled("Gain        : ", Style::default().fg(C_DIM)),
+                    Span::styled(format!("{} dB", ds.gain_db), Style::default().fg(C_TEXT)),
+                ])],
+                InputMode::Auto => vec![
+                    Line::from(vec![
+                        Span::styled("Position    : ", Style::default().fg(C_DIM)),
+                        Span::styled(ds.auto_position.to_string(), Style::default().fg(C_TEXT)),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Tone        : ", Style::default().fg(C_DIM)),
+                        Span::styled(ds.auto_tone.to_string(), Style::default().fg(C_TEXT)),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Auto Gain   : ", Style::default().fg(C_DIM)),
+                        Span::styled(ds.auto_gain.to_string(), Style::default().fg(C_TEXT)),
+                    ]),
+                ],
+            };
 
-    let mut lines = vec![
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("Mode        : ", Style::default().fg(C_DIM)),
-            Span::styled(ds.mode.to_string(), Style::default().fg(C_ACCENT)),
-        ]),
-    ];
-    lines.extend(mode_specific_lines);
-    lines.extend([
-        Line::from(vec![
-            Span::styled("Muted       : ", Style::default().fg(C_DIM)),
-            if ds.muted {
-                Span::styled("YES", Style::default().fg(C_ERROR))
+            let mut l = vec![
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("Mode        : ", Style::default().fg(C_DIM)),
+                    Span::styled(ds.mode.to_string(), Style::default().fg(C_ACCENT)),
+                ]),
+            ];
+            l.extend(mode_specific_lines);
+            l.extend([
+                Line::from(vec![
+                    Span::styled("Muted       : ", Style::default().fg(C_DIM)),
+                    if ds.muted {
+                        Span::styled("YES", Style::default().fg(C_ERROR))
+                    } else {
+                        Span::styled("NO", Style::default().fg(C_SUCCESS))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Locked      : ", Style::default().fg(C_DIM)),
+                    if ds.locked {
+                        Span::styled("YES", Style::default().fg(C_ERROR))
+                    } else {
+                        Span::styled("NO", Style::default().fg(C_DIM))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Phantom Pwr : ", Style::default().fg(C_DIM)),
+                    if ds.phantom_power {
+                        Span::styled("48V ON", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("OFF", Style::default().fg(C_DIM))
+                    },
+                ]),
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("EQ          : ", Style::default().fg(C_DIM)),
+                    if ds.mode == InputMode::Auto {
+                        Span::styled("auto", Style::default().fg(C_DISABLED))
+                    } else if ds.eq_enabled {
+                        Span::styled("Enabled", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("Bypass", Style::default().fg(C_DIM))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("HPF         : ", Style::default().fg(C_DIM)),
+                    if ds.mode == InputMode::Auto {
+                        Span::styled("auto", Style::default().fg(C_DISABLED))
+                    } else {
+                        Span::styled(ds.hpf.to_string(), Style::default().fg(C_TEXT))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Limiter     : ", Style::default().fg(C_DIM)),
+                    if ds.mode == InputMode::Auto {
+                        Span::styled("auto", Style::default().fg(C_DISABLED))
+                    } else if ds.limiter_enabled {
+                        Span::styled("ON", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("OFF", Style::default().fg(C_DIM))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Compressor  : ", Style::default().fg(C_DIM)),
+                    if ds.mode == InputMode::Auto {
+                        Span::styled("auto", Style::default().fg(C_DISABLED))
+                    } else {
+                        Span::styled(ds.compressor.to_string(), Style::default().fg(C_TEXT))
+                    },
+                ]),
+            ]);
+            l
+        }
+        DeviceModel::Mv6 => {
+            let pct = ds.tone as i32 * 10;
+            let tone_str = if pct < 0 {
+                format!("{}% Dark", pct.abs())
+            } else if pct > 0 {
+                format!("{}% Bright", pct)
             } else {
-                Span::styled("NO", Style::default().fg(C_SUCCESS))
-            },
-        ]),
-        Line::from(vec![
-            Span::styled("Locked      : ", Style::default().fg(C_DIM)),
-            if ds.locked {
-                Span::styled("YES", Style::default().fg(C_ERROR))
-            } else {
-                Span::styled("NO", Style::default().fg(C_DIM))
-            },
-        ]),
-        Line::from(vec![
-            Span::styled("Phantom Pwr : ", Style::default().fg(C_DIM)),
-            if ds.phantom_power {
-                Span::styled("48V ON", Style::default().fg(C_SUCCESS))
-            } else {
-                Span::styled("OFF", Style::default().fg(C_DIM))
-            },
-        ]),
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("EQ          : ", Style::default().fg(C_DIM)),
-            if ds.mode == InputMode::Auto {
-                Span::styled("auto", Style::default().fg(C_DISABLED))
-            } else if ds.eq_enabled {
-                Span::styled("Enabled", Style::default().fg(C_SUCCESS))
-            } else {
-                Span::styled("Bypass", Style::default().fg(C_DIM))
-            },
-        ]),
-        Line::from(vec![
-            Span::styled("HPF         : ", Style::default().fg(C_DIM)),
-            if ds.mode == InputMode::Auto {
-                Span::styled("auto", Style::default().fg(C_DISABLED))
-            } else {
-                Span::styled(ds.hpf.to_string(), Style::default().fg(C_TEXT))
-            },
-        ]),
-        Line::from(vec![
-            Span::styled("Limiter     : ", Style::default().fg(C_DIM)),
-            if ds.mode == InputMode::Auto {
-                Span::styled("auto", Style::default().fg(C_DISABLED))
-            } else if ds.limiter_enabled {
-                Span::styled("ON", Style::default().fg(C_SUCCESS))
-            } else {
-                Span::styled("OFF", Style::default().fg(C_DIM))
-            },
-        ]),
-        Line::from(vec![
-            Span::styled("Compressor  : ", Style::default().fg(C_DIM)),
-            if ds.mode == InputMode::Auto {
-                Span::styled("auto", Style::default().fg(C_DISABLED))
-            } else {
-                Span::styled(ds.compressor.to_string(), Style::default().fg(C_TEXT))
-            },
-        ]),
-    ]);
+                "Natural".to_string()
+            };
+            let mut l = vec![
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("Mode        : ", Style::default().fg(C_DIM)),
+                    Span::styled(ds.mode.to_string(), Style::default().fg(C_ACCENT)),
+                ]),
+            ];
+            if ds.mode == InputMode::Manual {
+                l.push(Line::from(vec![
+                    Span::styled("Gain        : ", Style::default().fg(C_DIM)),
+                    Span::styled(format!("{} dB", ds.gain_db), Style::default().fg(C_TEXT)),
+                ]));
+            }
+            l.extend([
+                Line::from(vec![
+                    Span::styled("Muted       : ", Style::default().fg(C_DIM)),
+                    if ds.muted {
+                        Span::styled("YES", Style::default().fg(C_ERROR))
+                    } else {
+                        Span::styled("NO", Style::default().fg(C_SUCCESS))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Mute Btn    : ", Style::default().fg(C_DIM)),
+                    if ds.mute_btn_disabled {
+                        Span::styled("Disabled", Style::default().fg(C_WARN))
+                    } else {
+                        Span::styled("Enabled", Style::default().fg(C_TEXT))
+                    },
+                ]),
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("Denoiser    : ", Style::default().fg(C_DIM)),
+                    if ds.denoiser_enabled {
+                        Span::styled("ON", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("OFF", Style::default().fg(C_DIM))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Pop. Stopper: ", Style::default().fg(C_DIM)),
+                    if ds.popper_stopper_enabled {
+                        Span::styled("ON", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("OFF", Style::default().fg(C_DIM))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Tone        : ", Style::default().fg(C_DIM)),
+                    Span::styled(tone_str, Style::default().fg(C_TEXT)),
+                ]),
+                Line::from(vec![
+                    Span::styled("HPF         : ", Style::default().fg(C_DIM)),
+                    Span::styled(ds.hpf.to_string(), Style::default().fg(C_TEXT)),
+                ]),
+            ]);
+            l
+        }
+    };
 
     let p = Paragraph::new(lines)
         .block(
@@ -913,9 +1097,256 @@ fn draw_meter(f: &mut Frame, app: &App, area: Rect) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Auto Level locked notice (shared by EQ and Dynamics tabs)
+// MV6 EQ Tab — Tone control
 // ─────────────────────────────────────────────────────────────────────────────
-fn draw_auto_mode_locked_notice(f: &mut Frame, area: Rect, tab_name: &str) {
+fn draw_mv6_eq_tab(f: &mut Frame, app: &App, area: Rect) {
+    let ds = &app.device_state;
+    let tone_foc = app.focus == Focus::Tone;
+    let tone = ds.tone;
+    let pct = tone as i32 * 10;
+    let tone_label = if pct < 0 {
+        format!("{}% Dark", pct.abs())
+    } else if pct > 0 {
+        format!("{}% Bright", pct)
+    } else {
+        "Natural".to_string()
+    };
+    let tone_ratio = (tone as f64 + 10.0) / 20.0;
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(0)])
+        .margin(1)
+        .split(area);
+
+    let tone_gauge = Gauge::default()
+        .block(
+            Block::default()
+                .title(Line::from(vec![
+                    Span::styled("  TONE  ", focused_style(tone_foc)),
+                    Span::styled(
+                        format!(" {} ", tone_label),
+                        Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        if tone_foc { "  ◄ ► to adjust" } else { "" },
+                        Style::default().fg(C_DIM),
+                    ),
+                ]))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(if tone_foc {
+                    Style::default().fg(C_FOCUS)
+                } else {
+                    Style::default().fg(C_BORDER)
+                }),
+        )
+        .gauge_style(
+            Style::default()
+                .fg(Color::Rgb(50, 150, 220))
+                .bg(C_SURFACE)
+                .add_modifier(if tone_foc { Modifier::BOLD } else { Modifier::empty() }),
+        )
+        .ratio(tone_ratio)
+        .label(format!("Dark ◄─{:+}─► Bright", pct));
+    f.render_widget(tone_gauge, rows[0]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MV6 Dynamics Tab — Denoiser, Popper Stopper, Mute Button, HPF
+// ─────────────────────────────────────────────────────────────────────────────
+fn draw_mv6_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
+    let ds = &app.device_state;
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .margin(1)
+        .split(area);
+
+    // ── Denoiser ──────────────────────────────────────────────────────────────
+    let den_foc = app.focus == Focus::Denoiser;
+    let den_p = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(C_DIM)),
+            bool_span(ds.denoiser_enabled),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Reduces background",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(Span::styled(
+            "noise in real time.",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "[Enter] to toggle",
+            Style::default().fg(if den_foc { C_FOCUS } else { C_DISABLED }),
+        )),
+    ])
+    .block(
+        Block::default()
+            .title(Span::styled(
+                "  Denoiser  ",
+                focused_style(den_foc),
+            ))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if den_foc {
+                Style::default().fg(C_FOCUS)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .padding(Padding::horizontal(1)),
+    );
+    f.render_widget(den_p, cols[0]);
+
+    // ── Popper Stopper ────────────────────────────────────────────────────────
+    let pop_foc = app.focus == Focus::PopperStopper;
+    let pop_p = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(C_DIM)),
+            bool_span(ds.popper_stopper_enabled),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Reduces plosive",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(Span::styled(
+            "sounds (p, b, t).",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "[Enter] to toggle",
+            Style::default().fg(if pop_foc { C_FOCUS } else { C_DISABLED }),
+        )),
+    ])
+    .block(
+        Block::default()
+            .title(Span::styled(
+                "  Popper Stopper  ",
+                focused_style(pop_foc),
+            ))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if pop_foc {
+                Style::default().fg(C_FOCUS)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .padding(Padding::horizontal(1)),
+    );
+    f.render_widget(pop_p, cols[1]);
+
+    // ── Mute Button Disable ───────────────────────────────────────────────────
+    let mbd_foc = app.focus == Focus::MuteBtnDisable;
+    let mbd_p = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Disabled: ", Style::default().fg(C_DIM)),
+            bool_span(ds.mute_btn_disabled),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Prevents the physical",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(Span::styled(
+            "mute button from",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(Span::styled("toggling mute.", Style::default().fg(C_DIM))),
+        Line::from(""),
+        Line::from(Span::styled(
+            "[Enter] to toggle",
+            Style::default().fg(if mbd_foc { C_FOCUS } else { C_DISABLED }),
+        )),
+    ])
+    .block(
+        Block::default()
+            .title(Span::styled(
+                "  Mute Button  ",
+                focused_style(mbd_foc),
+            ))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if mbd_foc {
+                Style::default().fg(C_FOCUS)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .padding(Padding::horizontal(1)),
+    );
+    f.render_widget(mbd_p, cols[2]);
+
+    // ── HPF ───────────────────────────────────────────────────────────────────
+    let hpf_foc = app.focus == Focus::Hpf;
+    let hpf_lines: Vec<Line> = [HpfFrequency::Off, HpfFrequency::Hz75, HpfFrequency::Hz150]
+        .iter()
+        .map(|freq| {
+            let selected = *freq == ds.hpf;
+            Line::from(vec![
+                Span::styled(
+                    if selected { "▶ " } else { "  " },
+                    Style::default().fg(C_ACCENT),
+                ),
+                Span::styled(
+                    freq.to_string(),
+                    if selected {
+                        Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(C_DIM)
+                    },
+                ),
+            ])
+        })
+        .collect();
+    let mut hpf_content = vec![Line::from("")];
+    hpf_content.extend(hpf_lines);
+    hpf_content.push(Line::from(""));
+    hpf_content.push(Line::from(Span::styled(
+        "[Enter] to cycle",
+        Style::default().fg(if hpf_foc { C_FOCUS } else { C_DISABLED }),
+    )));
+    let hpf_p = Paragraph::new(hpf_content).block(
+        Block::default()
+            .title(Span::styled(
+                "  High-Pass Filter  ",
+                if hpf_foc {
+                    Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(C_TEXT)
+                },
+            ))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if hpf_foc {
+                Style::default().fg(C_FOCUS)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .padding(Padding::horizontal(1)),
+    );
+    f.render_widget(hpf_p, cols[3]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tab locked / not-available notices
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Shown on EQ/Dynamics when MVX2U is in Auto Level mode.
+fn draw_tab_locked_notice(f: &mut Frame, area: Rect, tab_name: &str) {
     let lines = vec![
         Line::from(""),
         Line::from(Span::styled(
@@ -933,7 +1364,10 @@ fn draw_auto_mode_locked_notice(f: &mut Frame, area: Rect, tab_name: &str) {
             Style::default().fg(C_DIM),
         )),
     ];
+    render_notice(f, area, lines);
+}
 
+fn render_notice(f: &mut Frame, area: Rect, lines: Vec<Line>) {
     let p = Paragraph::new(lines)
         .block(
             Block::default()
@@ -951,8 +1385,12 @@ fn draw_auto_mode_locked_notice(f: &mut Frame, area: Rect, tab_name: &str) {
 // EQ Tab
 // ─────────────────────────────────────────────────────────────────────────────
 fn draw_eq_tab(f: &mut Frame, app: &App, area: Rect) {
+    if app.device_model == DeviceModel::Mv6 {
+        draw_mv6_eq_tab(f, app, area);
+        return;
+    }
     if app.device_state.mode == InputMode::Auto {
-        draw_auto_mode_locked_notice(f, area, "EQ");
+        draw_tab_locked_notice(f, area, "EQ");
         return;
     }
     let chunks = Layout::default()
@@ -1130,8 +1568,12 @@ fn draw_eq_tab(f: &mut Frame, app: &App, area: Rect) {
 // Dynamics Tab
 // ─────────────────────────────────────────────────────────────────────────────
 fn draw_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
+    if app.device_model == DeviceModel::Mv6 {
+        draw_mv6_dynamics_tab(f, app, area);
+        return;
+    }
     if app.device_state.mode == InputMode::Auto {
-        draw_auto_mode_locked_notice(f, area, "Dynamics");
+        draw_tab_locked_notice(f, area, "Dynamics");
         return;
     }
     let cols = Layout::default()
@@ -1373,7 +1815,7 @@ fn draw_preset_name_row(f: &mut Frame, app: &App, index: usize, area: Rect) {
 
     let summary_line = match &app.presets[index] {
         Some(slot) if !editing => {
-            Line::from(Span::styled(slot.summary(), Style::default().fg(C_DIM)))
+            Line::from(Span::styled(slot.summary(app.device_model), Style::default().fg(C_DIM)))
         }
         _ => Line::from(""),
     };
@@ -1486,7 +1928,14 @@ fn draw_preset_actions_row(f: &mut Frame, app: &App, index: usize, area: Rect) {
 // ─────────────────────────────────────────────────────────────────────────────
 fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
     let ds = &app.device_state;
-    let lines = vec![
+    let model = app.device_model;
+
+    let (vid_pid, gain_range) = match model {
+        DeviceModel::Mvx2u => ("14ED:1013", "0–60 dB"),
+        DeviceModel::Mv6 => ("14ED:1026", "0–36 dB"),
+    };
+
+    let mut lines = vec![
         Line::from(Span::styled(
             "  Device Information",
             Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
@@ -1497,11 +1946,8 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
             Span::styled("Shure Inc.", Style::default().fg(C_TEXT)),
         ]),
         Line::from(vec![
-            Span::styled("  Product      : ", Style::default().fg(C_DIM)),
-            Span::styled(
-                "shurectl / MVX2U Digital Audio Interface",
-                Style::default().fg(C_TEXT),
-            ),
+            Span::styled("  Model        : ", Style::default().fg(C_DIM)),
+            Span::styled(model.display_name(), Style::default().fg(C_TEXT)),
         ]),
         Line::from(vec![
             Span::styled("  Serial No.   : ", Style::default().fg(C_DIM)),
@@ -1509,7 +1955,7 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
         ]),
         Line::from(vec![
             Span::styled("  USB VID/PID  : ", Style::default().fg(C_DIM)),
-            Span::styled("14ED:1013", Style::default().fg(C_TEXT)),
+            Span::styled(vid_pid, Style::default().fg(C_TEXT)),
         ]),
         Line::from(""),
         Line::from(Span::styled(
@@ -1519,28 +1965,43 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::from(vec![
             Span::styled("  Gain Range   : ", Style::default().fg(C_DIM)),
-            Span::styled("0–60 dB", Style::default().fg(C_TEXT)),
-        ]),
-        Line::from(vec![
-            Span::styled("  Phantom Pwr  : ", Style::default().fg(C_DIM)),
-            Span::styled("48V", Style::default().fg(C_TEXT)),
-        ]),
-        Line::from(vec![
-            Span::styled("  EQ           : ", Style::default().fg(C_DIM)),
-            Span::styled("5-band parametric", Style::default().fg(C_TEXT)),
-        ]),
-        Line::from(vec![
-            Span::styled("  HPF          : ", Style::default().fg(C_DIM)),
-            Span::styled("Off / 75 Hz / 150 Hz", Style::default().fg(C_TEXT)),
-        ]),
-        Line::from(vec![
-            Span::styled("  Compressor   : ", Style::default().fg(C_DIM)),
-            Span::styled("Off / Light / Medium / Heavy", Style::default().fg(C_TEXT)),
+            Span::styled(gain_range, Style::default().fg(C_TEXT)),
         ]),
         Line::from(vec![
             Span::styled("  Presets      : ", Style::default().fg(C_DIM)),
-            Span::styled("4 slots", Style::default().fg(C_TEXT)),
+            Span::styled("4 slots (host-side TOML)", Style::default().fg(C_TEXT)),
         ]),
+    ];
+
+    let cap_rows: &[(&str, &str)] = match model {
+        DeviceModel::Mvx2u => &[
+            ("  Phantom Pwr  : ", "48V"),
+            ("  EQ           : ", "5-band parametric"),
+            ("  HPF          : ", "Off / 75 Hz / 150 Hz"),
+            ("  Compressor   : ", "Off / Light / Medium / Heavy"),
+            ("  Limiter      : ", "On / Off"),
+            ("  Monitor Mix  : ", "0–100%"),
+            ("  Auto Level   : ", "On / Off"),
+            ("  Config Lock  : ", "On / Off"),
+        ],
+        DeviceModel::Mv6 => &[
+            ("  Denoiser     : ", "On / Off"),
+            ("  Popper Stop. : ", "On / Off"),
+            ("  Tone         : ", "Dark (−100%) → Natural → Bright (+100%)"),
+            ("  HPF          : ", "Off / 75 Hz / 150 Hz"),
+            ("  Auto Level   : ", "On / Off"),
+            ("  Mute Button  : ", "Enable / Disable"),
+        ],
+    };
+
+    for (label, value) in cap_rows {
+        lines.push(Line::from(vec![
+            Span::styled(*label, Style::default().fg(C_DIM)),
+            Span::styled(*value, Style::default().fg(C_TEXT)),
+        ]));
+    }
+
+    lines.extend([
         Line::from(""),
         Line::from(Span::styled(
             concat!(
@@ -1550,11 +2011,14 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
             ),
             Style::default().fg(C_DIM),
         )),
-        Line::from(Span::styled(
+    ]);
+
+    if model == DeviceModel::Mvx2u {
+        lines.push(Line::from(Span::styled(
             "  Protocol reverse-engineered by PennRobotics/shux (Apache 2.0)",
             Style::default().fg(C_DISABLED),
-        )),
-    ];
+        )));
+    }
 
     let p = Paragraph::new(lines)
         .block(

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2024,13 +2024,6 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
         )),
     ]);
 
-    if model == DeviceModel::Mvx2u {
-        lines.push(Line::from(Span::styled(
-            "  Protocol reverse-engineered by PennRobotics/shux (Apache 2.0)",
-            Style::default().fg(C_DISABLED),
-        )));
-    }
-
     let p = Paragraph::new(lines)
         .block(
             Block::default()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -234,10 +234,18 @@ fn draw_main_left_mv6_manual(f: &mut Frame, app: &App, area: Rect) {
                     Span::styled("  GAIN  ", focused_style(gain_focused)),
                     Span::styled(
                         format!(" {} dB ", gain),
-                        Style::default().fg(if gain_locked { C_DIM } else { C_ACCENT }).add_modifier(Modifier::BOLD),
+                        Style::default()
+                            .fg(if gain_locked { C_DIM } else { C_ACCENT })
+                            .add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
-                        if gain_focused && !gain_locked { "  ◄ ► or ←→ to adjust" } else if gain_focused && gain_locked { "  🔒 locked" } else { "" },
+                        if gain_focused && !gain_locked {
+                            "  ◄ ► or ←→ to adjust"
+                        } else if gain_focused && gain_locked {
+                            "  🔒 locked"
+                        } else {
+                            ""
+                        },
                         Style::default().fg(C_DIM),
                     ),
                 ]))
@@ -249,9 +257,16 @@ fn draw_main_left_mv6_manual(f: &mut Frame, app: &App, area: Rect) {
                     Style::default().fg(C_BORDER)
                 }),
         )
-        .gauge_style(Style::default().fg(if gain_locked { C_DISABLED } else { C_ACCENT }).bg(C_SURFACE).add_modifier(
-            if gain_focused { Modifier::BOLD } else { Modifier::empty() },
-        ))
+        .gauge_style(
+            Style::default()
+                .fg(if gain_locked { C_DISABLED } else { C_ACCENT })
+                .bg(C_SURFACE)
+                .add_modifier(if gain_focused {
+                    Modifier::BOLD
+                } else {
+                    Modifier::empty()
+                }),
+        )
         .ratio(gain as f64 / app.device_model.max_gain_db() as f64)
         .label(format!("{gain} / {} dB", app.device_model.max_gain_db()));
     f.render_widget(gauge, rows[2]);
@@ -265,7 +280,10 @@ fn draw_main_left_mv6_manual(f: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(C_DIM),
         ),
         if gain_locked {
-            Span::styled("LOCKED", Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD))
+            Span::styled(
+                "LOCKED",
+                Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD),
+            )
         } else {
             Span::styled("Unlocked", Style::default().fg(C_SUCCESS))
         },
@@ -1145,7 +1163,11 @@ fn draw_mv6_eq_tab(f: &mut Frame, app: &App, area: Rect) {
             Style::default()
                 .fg(Color::Rgb(50, 150, 220))
                 .bg(C_SURFACE)
-                .add_modifier(if tone_foc { Modifier::BOLD } else { Modifier::empty() }),
+                .add_modifier(if tone_foc {
+                    Modifier::BOLD
+                } else {
+                    Modifier::empty()
+                }),
         )
         .ratio(tone_ratio)
         .label(format!("Dark ◄─{:+}─► Bright", pct));
@@ -1194,10 +1216,7 @@ fn draw_mv6_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
     ])
     .block(
         Block::default()
-            .title(Span::styled(
-                "  Denoiser  ",
-                focused_style(den_foc),
-            ))
+            .title(Span::styled("  Denoiser  ", focused_style(den_foc)))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(if den_foc {
@@ -1218,10 +1237,7 @@ fn draw_mv6_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
             bool_span(ds.popper_stopper_enabled),
         ]),
         Line::from(""),
-        Line::from(Span::styled(
-            "Reduces plosive",
-            Style::default().fg(C_DIM),
-        )),
+        Line::from(Span::styled("Reduces plosive", Style::default().fg(C_DIM))),
         Line::from(Span::styled(
             "sounds (p, b, t).",
             Style::default().fg(C_DIM),
@@ -1234,10 +1250,7 @@ fn draw_mv6_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
     ])
     .block(
         Block::default()
-            .title(Span::styled(
-                "  Popper Stopper  ",
-                focused_style(pop_foc),
-            ))
+            .title(Span::styled("  Popper Stopper  ", focused_style(pop_foc)))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(if pop_foc {
@@ -1262,10 +1275,7 @@ fn draw_mv6_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
             "Prevents the physical",
             Style::default().fg(C_DIM),
         )),
-        Line::from(Span::styled(
-            "mute button from",
-            Style::default().fg(C_DIM),
-        )),
+        Line::from(Span::styled("mute button from", Style::default().fg(C_DIM))),
         Line::from(Span::styled("toggling mute.", Style::default().fg(C_DIM))),
         Line::from(""),
         Line::from(Span::styled(
@@ -1275,10 +1285,7 @@ fn draw_mv6_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
     ])
     .block(
         Block::default()
-            .title(Span::styled(
-                "  Mute Button  ",
-                focused_style(mbd_foc),
-            ))
+            .title(Span::styled("  Mute Button  ", focused_style(mbd_foc)))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(if mbd_foc {
@@ -1814,9 +1821,10 @@ fn draw_preset_name_row(f: &mut Frame, app: &App, index: usize, area: Rect) {
     };
 
     let summary_line = match &app.presets[index] {
-        Some(slot) if !editing => {
-            Line::from(Span::styled(slot.summary(app.device_model), Style::default().fg(C_DIM)))
-        }
+        Some(slot) if !editing => Line::from(Span::styled(
+            slot.summary(app.device_model),
+            Style::default().fg(C_DIM),
+        )),
         _ => Line::from(""),
     };
 
@@ -1987,7 +1995,10 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
         DeviceModel::Mv6 => &[
             ("  Denoiser     : ", "On / Off"),
             ("  Popper Stop. : ", "On / Off"),
-            ("  Tone         : ", "Dark (−100%) → Natural → Bright (+100%)"),
+            (
+                "  Tone         : ",
+                "Dark (−100%) → Natural → Bright (+100%)",
+            ),
             ("  HPF          : ", "Off / 75 Hz / 150 Hz"),
             ("  Auto Level   : ", "On / Off"),
             ("  Mute Button  : ", "Enable / Disable"),


### PR DESCRIPTION
Adds full support for the Shure MV6 USB gaming microphone (VID 14ed, PID 1026) alongside the existing MVX2U implementation.

Device support:
- Auto-detect MV6 vs MVX2U at startup via USB PID; --list enumerates both devices
- DeviceModel enum gates model-specific UI, actions, and state readback
- Separate get_state_mv6() getter sequence for MV6 feature addresses

MV6 features implemented:
- Gain: manual 0–36 dB and auto-gain mode
- Tone: −100% (dark) to +100% (bright) in 10% increments
- Real-time denoiser toggle
- Popper stopper toggle
- Hardware mute button disable toggle
- High-pass filter: Off / 75 Hz / 150 Hz

Protocol:
- MV6_FEAT_* constants for all MV6 feature addresses (verified via usbmon capture against ShurePlus MOTIV Desktop app)
- cmd_get_mv6_* / cmd_set_mv6_* constructors in protocol.rs
- apply_response() branches for all MV6 feature addresses
- Roundtrip tests for all new packet constructors

Presets:
- PresetSlot extended with MV6-specific fields (denoiser_enabled, popper_stopper_enabled, mute_btn_disabled, tone) files clean; serde defaults ensure backwards compatibility
- save_mv6_state() / load_mv6_state() persist mute_btn_disabled across sessions (device does not retain this across power cycles)
- LoadPreset on MV6 persists mv6_state.toml after applying

UI:
- Dynamics tab renders MV6-specific controls (Denoiser, Popper Stopper, Mute Button disable) when MV6 is active
- Main page summary includes Mute Btn status for MV6

Quality:
- debug_assert! → assert! for EQ bounds and UI invariants
- EnableMouseCapture removed (no mouse event handling was present)
- TOCTOU races in presets.rs replaced with ErrorKind::NotFound matching
- Non-atomic preset saves use write-to-temp-then-rename pattern
- All 172 tests passing; clippy clean with -D warnings