### PR TITLE
feat(mv6): add monitor mix control and eliminate host-side state pers…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shurectl"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 description = "shurectl — TUI configurator for the Shure MVX2U audio interface"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -523,7 +523,6 @@ impl App {
 #[derive(Debug)]
 pub enum DeviceAction {
     SetGain(u8),
-    /// Carry the full `InputMode` so callers never have to interpret a bare bool.
     SetMode(InputMode),
     SetAutoPosition(MicPosition),
     SetAutoTone(AutoTone),
@@ -551,11 +550,8 @@ pub enum DeviceAction {
     /// Uses the same 0–100 encoding as MVX2U but requires HDR_CONSTANT=0x00 on the wire.
     SetMv6MonitorMix(u8),
     // ── Preset actions ────────────────────────────────────────────────────────
-    /// Save current device state to preset slot `usize`.
     SavePreset(usize),
-    /// Load preset slot `usize` and apply all settings to the device.
     LoadPreset(usize),
-    /// Delete the preset file for slot `usize`.
     DeletePreset(usize),
     /// Write the (already in-memory-updated) preset name for slot `usize` back to disk.
     PersistPresetName(usize),

--- a/src/app.rs
+++ b/src/app.rs
@@ -221,8 +221,8 @@ impl App {
     //   Auto:   Mode → Mute → AutoPosition → AutoTone → AutoGain → MonitorMix → Phantom → Lock → (wrap)
     //
     // MV6 Main cycles (mirrors MVX2U structure, no extra controls):
-    //   Manual: Mode → Mute → Gain → GainLock → (wrap)
-    //   Auto:   Mode → Mute → (wrap)
+    //   Manual: Mode → Mute → Gain → GainLock → MonitorMix → (wrap)
+    //   Auto:   Mode → Mute → MonitorMix → (wrap)
     //
     // MV6 EQ:      Tone (slider only, no bands)
     // MV6 Dynamics: Denoiser → PopperStopper → MuteBtnDisable → Hpf → (wrap)
@@ -237,9 +237,11 @@ impl App {
             (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Manual) => Focus::Mute,
             (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Manual) => Focus::Gain,
             (Tab::Main, Focus::Gain, DeviceModel::Mv6, InputMode::Manual) => Focus::GainLock,
-            (Tab::Main, Focus::GainLock, DeviceModel::Mv6, InputMode::Manual) => Focus::Mode,
+            (Tab::Main, Focus::GainLock, DeviceModel::Mv6, InputMode::Manual) => Focus::MonitorMix,
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mv6, InputMode::Manual) => Focus::Mode,
             (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Auto) => Focus::Mute,
-            (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Auto) => Focus::MonitorMix,
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mv6, InputMode::Auto) => Focus::Mode,
             (Tab::Main, _, DeviceModel::Mv6, _) => Focus::Mode,
 
             // ── MVX2U Manual cycle ────────────────────────────────────────────
@@ -303,12 +305,14 @@ impl App {
             &self.device_state.mode,
         ) {
             // ── MV6 Main reverse ──────────────────────────────────────────────
-            (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Manual) => Focus::GainLock,
+            (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Manual) => Focus::MonitorMix,
             (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Manual) => Focus::Mode,
             (Tab::Main, Focus::Gain, DeviceModel::Mv6, InputMode::Manual) => Focus::Mute,
             (Tab::Main, Focus::GainLock, DeviceModel::Mv6, InputMode::Manual) => Focus::Gain,
-            (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mv6, InputMode::Manual) => Focus::GainLock,
+            (Tab::Main, Focus::Mode, DeviceModel::Mv6, InputMode::Auto) => Focus::MonitorMix,
             (Tab::Main, Focus::Mute, DeviceModel::Mv6, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mv6, InputMode::Auto) => Focus::Mute,
             (Tab::Main, _, DeviceModel::Mv6, _) => Focus::Mode,
 
             // ── MVX2U Manual reverse ──────────────────────────────────────────
@@ -380,11 +384,16 @@ impl App {
             Focus::MonitorMix => {
                 let m = &mut self.device_state.monitor_mix;
                 if delta > 0 {
-                    *m = (*m + 5).min(100);
+                    *m = (*m + 1).min(100);
                 } else {
-                    *m = m.saturating_sub(5);
+                    *m = m.saturating_sub(1);
                 }
-                Some(DeviceAction::SetMonitorMix(self.device_state.monitor_mix))
+                let mix = self.device_state.monitor_mix;
+                if self.device_model == DeviceModel::Mv6 {
+                    Some(DeviceAction::SetMv6MonitorMix(mix))
+                } else {
+                    Some(DeviceAction::SetMonitorMix(mix))
+                }
             }
             Focus::Tone => {
                 let t = &mut self.device_state.tone;
@@ -538,6 +547,9 @@ pub enum DeviceAction {
     /// Tone in steps of 1 (−10 to +10); displayed as × 10%.
     SetMv6Tone(i8),
     SetMv6GainLock(bool),
+    /// Monitor mix: 0 = full mic, 100 = full playback. MV6 only.
+    /// Uses the same 0–100 encoding as MVX2U but requires HDR_CONSTANT=0x00 on the wire.
+    SetMv6MonitorMix(u8),
     // ── Preset actions ────────────────────────────────────────────────────────
     /// Save current device state to preset slot `usize`.
     SavePreset(usize),
@@ -787,12 +799,13 @@ mod tests {
 
     #[test]
     fn mv6_main_tab_manual_mode_focus_cycles_forward_and_back() {
-        // MV6 Manual: Mode → Mute → Gain → GainLock → Mode
+        // MV6 Manual: Mode → Mute → Gain → GainLock → MonitorMix → Mode
         let forward = [
             Focus::Mode,
             Focus::Mute,
             Focus::Gain,
             Focus::GainLock,
+            Focus::MonitorMix,
             Focus::Mode, // wrap
         ];
         let mut app = App::default();
@@ -806,14 +819,37 @@ mod tests {
             assert_eq!(app.focus, *expected, "focus_next: expected {expected:?}");
         }
 
-        // Backward from Mode wraps to GainLock
+        // Backward from Mode wraps to MonitorMix
         app.focus = Focus::Mode;
         app.focus_prev();
-        assert_eq!(app.focus, Focus::GainLock);
+        assert_eq!(app.focus, Focus::MonitorMix);
 
-        // Backward from GainLock goes to Gain
+        // Backward from MonitorMix goes to GainLock
         app.focus_prev();
-        assert_eq!(app.focus, Focus::Gain);
+        assert_eq!(app.focus, Focus::GainLock);
+    }
+
+    #[test]
+    fn mv6_main_tab_auto_mode_focus_cycles_forward_and_back() {
+        // MV6 Auto: Mode → Mute → MonitorMix → Mode
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mv6;
+        app.active_tab = Tab::Main;
+        app.device_state.mode = InputMode::Auto;
+        app.focus = Focus::Mode;
+
+        app.focus_next();
+        assert_eq!(app.focus, Focus::Mute);
+        app.focus_next();
+        assert_eq!(app.focus, Focus::MonitorMix);
+        app.focus_next();
+        assert_eq!(app.focus, Focus::Mode); // wrap
+
+        // Backward from Mode wraps to MonitorMix
+        app.focus_prev();
+        assert_eq!(app.focus, Focus::MonitorMix);
+        app.focus_prev();
+        assert_eq!(app.focus, Focus::Mute);
     }
 
     #[test]
@@ -903,10 +939,10 @@ mod tests {
     }
 
     #[test]
-    fn adjust_monitor_mix_steps_by_five_and_clamps() {
+    fn adjust_monitor_mix_steps_by_one_and_clamps() {
         let mut app = App::default();
         app.focus = Focus::MonitorMix;
-        app.device_state.monitor_mix = 95;
+        app.device_state.monitor_mix = 99;
 
         app.adjust_focused(1);
         assert_eq!(app.device_state.monitor_mix, 100);
@@ -917,11 +953,40 @@ mod tests {
             "monitor mix must not exceed 100"
         );
 
-        app.device_state.monitor_mix = 3;
+        app.device_state.monitor_mix = 1;
         app.adjust_focused(-1);
         assert_eq!(
             app.device_state.monitor_mix, 0,
             "monitor mix must not underflow"
+        );
+    }
+
+    #[test]
+    fn adjust_monitor_mix_dispatches_set_mv6_monitor_mix_for_mv6() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mv6;
+        app.focus = Focus::MonitorMix;
+        app.device_state.monitor_mix = 50;
+
+        let action = app.adjust_focused(1);
+        assert_eq!(app.device_state.monitor_mix, 51);
+        assert!(
+            matches!(action, Some(DeviceAction::SetMv6MonitorMix(51))),
+            "MV6 must dispatch SetMv6MonitorMix, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn adjust_monitor_mix_dispatches_set_monitor_mix_for_mvx2u() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mvx2u;
+        app.focus = Focus::MonitorMix;
+        app.device_state.monitor_mix = 50;
+
+        let action = app.adjust_focused(1);
+        assert!(
+            matches!(action, Some(DeviceAction::SetMonitorMix(51))),
+            "MVX2U must dispatch SetMonitorMix, got {action:?}"
         );
     }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -256,9 +256,6 @@ impl ShureDevice {
     fn get_state_mv6(&self) -> Result<DeviceState> {
         let mut state = DeviceState::default();
 
-        // MV6 shares gain, mute, HPF, and auto level addresses with the MVX2U.
-        // mute_btn_disable GET uses CMD_GET_LOCK class with a non-standard payload layout;
-        // parse_response handles it correctly via MV6_FEAT_MUTE_BTN_DISABLE_RESP=[0x00,0x60].
         let getters: &[fn(u8) -> Vec<u8>] = &[
             cmd_get_gain,
             cmd_get_mute,

--- a/src/device.rs
+++ b/src/device.rs
@@ -40,8 +40,8 @@ use crate::protocol::{
     cmd_get_auto_gain, cmd_get_auto_position, cmd_get_auto_tone, cmd_get_compressor,
     cmd_get_eq_band_enable, cmd_get_eq_band_gain, cmd_get_eq_enable, cmd_get_gain, cmd_get_hpf,
     cmd_get_limiter, cmd_get_lock, cmd_get_mix, cmd_get_mode, cmd_get_mute, cmd_get_mv6_denoiser,
-    cmd_get_mv6_gain_lock, cmd_get_mv6_popper_stopper, cmd_get_mv6_tone, cmd_get_phantom,
-    cmd_set_lock, parse_response,
+    cmd_get_mv6_gain_lock, cmd_get_mv6_mix, cmd_get_mv6_mute_btn_disable,
+    cmd_get_mv6_popper_stopper, cmd_get_mv6_tone, cmd_get_phantom, cmd_set_lock, parse_response,
 };
 
 #[cfg(target_os = "linux")]
@@ -257,8 +257,8 @@ impl ShureDevice {
         let mut state = DeviceState::default();
 
         // MV6 shares gain, mute, HPF, and auto level addresses with the MVX2U.
-        // mute_btn_disabled is persisted host-side (see presets::Mv6State) because
-        // the device always returns the same value for that GET regardless of state.
+        // mute_btn_disable GET uses CMD_GET_LOCK class with a non-standard payload layout;
+        // parse_response handles it correctly via MV6_FEAT_MUTE_BTN_DISABLE_RESP=[0x00,0x60].
         let getters: &[fn(u8) -> Vec<u8>] = &[
             cmd_get_gain,
             cmd_get_mute,
@@ -268,6 +268,8 @@ impl ShureDevice {
             cmd_get_mv6_popper_stopper,
             cmd_get_mv6_tone,
             cmd_get_mv6_gain_lock,
+            cmd_get_mv6_mix,
+            cmd_get_mv6_mute_btn_disable,
         ];
 
         self.run_getters(getters, &mut state, "get_state(mv6)");
@@ -375,6 +377,10 @@ impl ShureDevice {
 
     pub fn set_mv6_gain_lock(&self, locked: bool) -> Result<()> {
         self.send_set(&protocol::cmd_set_mv6_gain_lock(self.next_seq(), locked))
+    }
+
+    pub fn set_mv6_monitor_mix(&self, mix: u8) -> Result<()> {
+        self.send_set(&protocol::cmd_set_mv6_mix(self.next_seq(), mix))
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,10 +116,6 @@ fn main() -> Result<()> {
         match dev.get_state() {
             Ok(mut state) => {
                 state.serial_number = dev.serial_number.clone();
-                if dev.model == DeviceModel::Mv6 {
-                    let mv6 = presets::load_mv6_state();
-                    state.mute_btn_disabled = mv6.mute_btn_disabled;
-                }
                 app.device_state = state;
                 app.set_ok(format!(
                     "Connected to {} — state loaded.",
@@ -407,11 +403,6 @@ fn apply_action(app: &mut App, device: &Option<ShureDevice>, action: DeviceActio
                 "Mute Button → {}",
                 if *disabled { "Disabled" } else { "Enabled" }
             ));
-            if let Err(e) = presets::save_mv6_state(&presets::Mv6State {
-                mute_btn_disabled: *disabled,
-            }) {
-                eprintln!("Warning: failed to save MV6 state: {e}");
-            }
             send_if_connected(device, |d| d.set_mv6_mute_btn_disable(*disabled))
         }
         DeviceAction::SetMv6Tone(tone) => {
@@ -434,6 +425,10 @@ fn apply_action(app: &mut App, device: &Option<ShureDevice>, action: DeviceActio
             });
             send_if_connected(device, |d| d.set_mv6_gain_lock(*locked))
         }
+        DeviceAction::SetMv6MonitorMix(m) => {
+            app.set_ok(format!("Monitor mix → {}%", m));
+            send_if_connected(device, |d| d.set_mv6_monitor_mix(*m))
+        }
         // ── Preset actions ────────────────────────────────────────────────────
         DeviceAction::SavePreset(i) => {
             let name = app.presets[*i]
@@ -454,17 +449,7 @@ fn apply_action(app: &mut App, device: &Option<ShureDevice>, action: DeviceActio
             if let Some(slot) = &app.presets[*i].clone() {
                 slot.apply_to_device_state(&mut app.device_state);
                 app.set_ok(format!("Loaded \"{}\".", slot.name));
-                let result = apply_preset_to_device(device, &app.device_state, app.device_model);
-                // mute_btn_disabled cannot be read back from the MV6, so we persist
-                // the preset value to mv6_state.toml so a restart doesn't revert it.
-                if app.device_model == DeviceModel::Mv6
-                    && let Err(e) = presets::save_mv6_state(&presets::Mv6State {
-                        mute_btn_disabled: app.device_state.mute_btn_disabled,
-                    })
-                {
-                    eprintln!("Warning: failed to persist MV6 state after preset load: {e}");
-                }
-                result
+                apply_preset_to_device(device, &app.device_state, app.device_model)
             } else {
                 app.set_err(format!("Preset slot {} is empty.", i + 1));
                 Ok(())
@@ -545,6 +530,7 @@ fn apply_preset_to_device(
                 d.set_mv6_mute_btn_disable(state.mute_btn_disabled)?;
                 d.set_mv6_tone(state.tone)?;
                 d.set_mv6_gain_lock(state.mv6_gain_locked)?;
+                d.set_mv6_monitor_mix(state.monitor_mix)?;
             }
         }
         Ok(())

--- a/src/meter.rs
+++ b/src/meter.rs
@@ -180,7 +180,7 @@ pub fn start_meter(level: Arc<AtomicI32>, peak_window: Arc<Mutex<PeakWindow>>) -
         SampleFormat::U16 => {
             build_stream::<u16>(&device, &stream_config, level, peak_window, err_fn)
         }
-        // cpal 0.15 added more formats; handle them all the same way.
+        // Fallback for any other sample formats.
         _ => build_stream::<f32>(&device, &stream_config, level, peak_window, err_fn),
     };
 

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -271,46 +271,6 @@ pub fn load_all_presets() -> [Option<PresetSlot>; PRESET_COUNT] {
     })
 }
 
-// ── MV6 persistent state ──────────────────────────────────────────────────────
-//
-// Some MV6 settings cannot be read back from the device (the mute button disable
-// state always returns the same value regardless of what was set). We persist
-// these host-side in ~/.config/shurectl/mv6_state.toml.
-
-/// Host-side persistent state for MV6 settings that cannot be read from the device.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-pub struct Mv6State {
-    /// Whether the physical mute button is disabled.
-    #[serde(default)]
-    pub mute_btn_disabled: bool,
-}
-
-/// Load MV6 persistent state from `~/.config/shurectl/mv6_state.toml`.
-/// Returns default (all false) if the file does not exist or cannot be parsed.
-pub fn load_mv6_state() -> Mv6State {
-    let path = match config_dir() {
-        Ok(dir) => dir.join("mv6_state.toml"),
-        Err(_) => return Mv6State::default(),
-    };
-    let text = match std::fs::read_to_string(&path) {
-        Ok(t) => t,
-        Err(_) => return Mv6State::default(),
-    };
-    toml::from_str(&text).unwrap_or_default()
-}
-
-/// Save MV6 persistent state to `~/.config/shurectl/mv6_state.toml`.
-pub fn save_mv6_state(state: &Mv6State) -> Result<()> {
-    let path = config_dir()?.join("mv6_state.toml");
-    let text = toml::to_string_pretty(state).context("Failed to serialise MV6 state")?;
-    let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, &text)
-        .with_context(|| format!("Failed to write MV6 state: {}", tmp.display()))?;
-    std::fs::rename(&tmp, &path)
-        .with_context(|| format!("Failed to rename MV6 state file: {}", path.display()))?;
-    Ok(())
-}
-
 // ── Serialisable mirror types ─────────────────────────────────────────────────
 //
 // We use separate mirror enums with `#[derive(Serialize, Deserialize)]` rather
@@ -688,7 +648,7 @@ mod tests {
             auto_gain: AutoGain::Normal,
             muted: false,
             phantom_power: false,
-            monitor_mix: 0,
+            monitor_mix: 62,
             limiter_enabled: false,
             compressor: CompressorPreset::Off,
             hpf: HpfFrequency::Hz75,
@@ -719,6 +679,10 @@ mod tests {
         assert!(decoded.mute_btn_disabled);
         assert_eq!(decoded.tone, 5);
         assert_eq!(decoded.hpf, SerHpfFrequency::Hz75);
+        assert_eq!(
+            decoded.monitor_mix, 62,
+            "monitor_mix must survive TOML roundtrip"
+        );
     }
 
     #[test]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -89,8 +89,7 @@
 //!   Gain lock:       [0x01, 0xF3]  — 1 byte: 0=unlocked, 1=locked (Manual mode only)
 //!                                    Confirmed by probe diff: value changed 0x00→0x01 when
 //!                                    gain lock was enabled in MOTIV Mix. Standard CMD_GET_FEAT
-//!                                    / CMD_SET_FEAT, prefix 0x00. SET encoding unverified —
-//!                                    verify with usbmon if toggling does not take effect.
+//!                                    / CMD_SET_FEAT, prefix 0x00. SET confirmed working.
 //!   Tone:            [0x02, 0x04]  — 16-bit signed big-endian, units: percent
 //!                                    Range: -100 (Dark) to +100 (Bright), steps of 10.
 //!                                    0 = Natural (confirmed at factory default).
@@ -210,7 +209,7 @@ const MV6_FEAT_MUTE_BTN_DISABLE_RESP: [u8; 2] = [0x00, 0x60];
 const MV6_FEAT_TONE: [u8; 2] = [0x02, 0x04];
 /// MV6 gain lock (Manual mode only). 0=unlocked, 1=locked.
 /// Confirmed by probe diff against MOTIV Mix with gain lock on/off.
-/// SET encoding assumed standard CMD_SET_FEAT / prefix 0x00 — verify with usbmon if misbehaving.
+/// SET confirmed working: standard CMD_SET_FEAT / prefix 0x00.
 const MV6_FEAT_GAIN_LOCK: [u8; 2] = [0x01, 0xF3];
 // ── Phantom power value encoding ──────────────────────────────────────────────
 const PHANTOM_ON: u8 = 0x30; // 48 decimal = 48V
@@ -592,12 +591,9 @@ pub fn crc16_ansi(data: &[u8]) -> u16 {
 /// ```
 /// CRC-16/ANSI covers from `[0x11]` to end of payload (exclusive of CRC bytes).
 fn build_packet(seq: u8, cmd: &[u8; 3], payload: &[u8]) -> Vec<u8> {
-    // Inner data section: DATA_START + data_len + cmd + payload
-    // data_len = cmd(3) + payload.len() + 2 (for the data_len byte itself + DATA_START byte)
+    // data_len counts: DATA_START(1) + data_len(1) + cmd(3) + payload
     let data_len = (3 + payload.len() + 2) as u8;
 
-    // Wire content (everything after report ID, before CRC and padding):
-    // [total_len][0x11][0x22][seq][0x03][0x08][data_len][0x70][data_len][cmd...][payload...]
     let mut inner: Vec<u8> = Vec::with_capacity(PACKET_SIZE);
     inner.push(HEADER_MAGIC[0]);
     inner.push(HEADER_MAGIC[1]);
@@ -610,13 +606,9 @@ fn build_packet(seq: u8, cmd: &[u8; 3], payload: &[u8]) -> Vec<u8> {
     inner.extend_from_slice(cmd);
     inner.extend_from_slice(payload);
 
-    // total_len = inner.len() + 2 (for the two CRC bytes)
-    let total_len = (inner.len() + 2) as u8;
-
-    // CRC covers everything in `inner` (i.e. from 0x11 onward)
+    let total_len = (inner.len() + 2) as u8; // +2 for CRC bytes
     let crc = crc16_ansi(&inner);
 
-    // Assemble: [REPORT_ID][total_len][inner...][crc_hi][crc_lo][padding...]
     let mut pkt: Vec<u8> = Vec::with_capacity(PACKET_SIZE);
     pkt.push(REPORT_ID);
     pkt.push(total_len);
@@ -636,7 +628,7 @@ fn build_packet(seq: u8, cmd: &[u8; 3], payload: &[u8]) -> Vec<u8> {
 pub fn parse_response(buf: &[u8]) -> Option<([u8; 2], Vec<u8>)> {
     // Minimum: report_id(1) + total_len(1) + header(2) + seq(1) + 0x03(1) +
     //          hdr_end(1) + data_len(1) + data_start(1) + data_len(1) +
-    //          cmd(3) + is_mix(1) + feat(2) + crc(2) = 18 bytes minimum
+    //          cmd(3) + prefix(1) + feat(2) + crc(2) = 18 bytes minimum
     if buf.len() < 18 {
         return None;
     }
@@ -671,7 +663,7 @@ pub fn parse_response(buf: &[u8]) -> Option<([u8; 2], Vec<u8>)> {
         return None;
     }
 
-    // buf[13] = is_mix byte (ignored for our purposes)
+    // buf[13] = prefix byte (is_mix/lock-class flag; ignored for our purposes)
     // buf[14..16] = feature address
     if buf.len() < 16 {
         return None;
@@ -792,14 +784,12 @@ pub fn cmd_get_mv6_mute_btn_disable(seq: u8) -> Vec<u8> {
 
 /// Build a GET packet for the config-lock feature.
 pub fn cmd_get_lock(seq: u8) -> Vec<u8> {
-    // Payload: [0x06][feat_addr]  — lock uses 0x06 as the is_mix_or_lock byte.
     let payload = [0x06, FEAT_LOCK[0], FEAT_LOCK[1]];
     build_packet(seq, &CMD_GET_LOCK, &payload)
 }
 
 /// Build a SET packet for the config-lock feature.
 /// `locked = true` locks the device; `false` unlocks it.
-/// Must be followed by a CONFIRM packet (use `cmd_confirm`).
 pub fn cmd_set_lock(seq: u8, locked: bool) -> Vec<u8> {
     let value: u8 = u8::from(locked);
     let payload = [0x06, FEAT_LOCK[0], FEAT_LOCK[1], value];
@@ -823,9 +813,8 @@ pub fn cmd_get_eq_band_gain(seq: u8, band: usize) -> Vec<u8> {
 
 // ── Public SET constructors ───────────────────────────────────────────────────
 
-/// Set manual gain. `gain_db` is the already-clamped value from `device.rs::set_gain`,
-/// which enforces the model-specific ceiling (60 dB MVX2U, 36 dB MV6).
-/// Encoded as `gain_db * 100` in 16-bit big-endian. Shared by both devices.
+/// Set manual gain. Encoded as `gain_db * 100` in 16-bit big-endian.
+/// Clamping to the model-specific ceiling is the caller's responsibility.
 pub fn cmd_set_gain(seq: u8, gain_db: u8) -> Vec<u8> {
     let raw = gain_db as u16 * 100;
     cmd_set(seq, &FEAT_GAIN, &raw.to_be_bytes())
@@ -942,15 +931,15 @@ pub fn cmd_set_mv6_mute_btn_disable(seq: u8, disabled: bool) -> Vec<u8> {
     inner.push(HEADER_MAGIC[0]);
     inner.push(HEADER_MAGIC[1]);
     inner.push(seq);
-    inner.push(0x00); // HDR_CONSTANT: 0x00 for this command (not the usual 0x03)
+    inner.push(0x00); // HDR_CONSTANT=0x00 for this command (not the usual 0x03)
     inner.push(HDR_END);
     inner.push(data_len);
     inner.push(DATA_START);
     inner.push(data_len);
-    inner.extend_from_slice(&CMD_SET_LOCK); // [02 02 01], not CMD_SET_FEAT [02 02 02]
+    inner.extend_from_slice(&CMD_SET_LOCK); // [02 02 01], not CMD_SET_FEAT
     inner.extend_from_slice(&payload);
 
-    let total_len = (inner.len() + 2) as u8;
+    let total_len = (inner.len() + 2) as u8; // +2 for CRC bytes
     let crc = crc16_ansi(&inner);
 
     let mut pkt: Vec<u8> = Vec::with_capacity(PACKET_SIZE);
@@ -978,7 +967,7 @@ pub fn cmd_set_mv6_mix(seq: u8, mix: u8) -> Vec<u8> {
     inner.push(HEADER_MAGIC[0]);
     inner.push(HEADER_MAGIC[1]);
     inner.push(seq);
-    inner.push(0x00); // HDR_CONSTANT: 0x00 (confirmed by Wireshark; not the usual 0x03)
+    inner.push(0x00); // HDR_CONSTANT=0x00 (not the usual 0x03)
     inner.push(HDR_END);
     inner.push(data_len);
     inner.push(DATA_START);
@@ -986,7 +975,7 @@ pub fn cmd_set_mv6_mix(seq: u8, mix: u8) -> Vec<u8> {
     inner.extend_from_slice(&CMD_SET_FEAT);
     inner.extend_from_slice(&payload);
 
-    let total_len = (inner.len() + 2) as u8;
+    let total_len = (inner.len() + 2) as u8; // +2 for CRC bytes
     let crc = crc16_ansi(&inner);
 
     let mut pkt: Vec<u8> = Vec::with_capacity(PACKET_SIZE);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -69,10 +69,23 @@
 //!   Denoiser:        [0x01, 0x58]  — 1 byte: 0=off, 1=on  (GET-readable, confirmed)
 //!   Auto level:      [0x01, 0x85]  — 1 byte: 0=manual, 1=auto
 //!   Popper stopper:  [0x03, 0x81]  — 1 byte: 0=off, 1=on  (confirmed by MOTIV app probe diff)
-//!   Mute btn disable:[0x0C, 0x00]  — SET uses cmd [02 02 01], HDR_CONSTANT=0x00,
+//!   Mute btn disable:[0x0C, 0x00]  — GET uses cmd [01 02 01], HDR_CONSTANT=0x03,
+//!                                    payload [addr_hi, addr_lo, 0x60].
+//!                                    SET uses cmd [02 02 01], HDR_CONSTANT=0x00,
 //!                                    payload [addr_hi, addr_lo, 0x60, enable_byte].
 //!                                    enable_byte: 0x00=disabled, 0x01=active (inverted).
-//!                                    State persisted host-side; GET unreliable.
+//!                                    parse_response sees feat_addr=[0x00, 0x60] because
+//!                                    addr bytes appear at payload[0..2]. GET confirmed
+//!                                    reliable by Wireshark — state read from device.
+//!   Monitor mix:     [0x01, 0x86]  — 1 byte: 0=full mic, 100=full playback. Same address
+//!                                    as MVX2U FEAT_MIX. SET confirmed by Wireshark capture
+//!                                    of MOTIV app: HDR_CONSTANT=0x00 (not the usual 0x03),
+//!                                    CMD_SET_FEAT [02 02 02], prefix 0x00, value is 0–100.
+//!                                    GET uses standard framing (HDR_CONSTANT=0x03, prefix
+//!                                    0x00) — confirmed by Wireshark. Device only responds
+//!                                    to GET after at least one SET has been issued; a fresh
+//!                                    device returns nothing (explains why probe sweep missed
+//!                                    it). See cmd_get_mv6_mix() / cmd_set_mv6_mix().
 //!   Gain lock:       [0x01, 0xF3]  — 1 byte: 0=unlocked, 1=locked (Manual mode only)
 //!                                    Confirmed by probe diff: value changed 0x00→0x01 when
 //!                                    gain lock was enabled in MOTIV Mix. Standard CMD_GET_FEAT
@@ -182,9 +195,16 @@ const MV6_FEAT_DENOISER: [u8; 2] = [0x01, 0x58];
 /// popper stopper in MOTIV changes this address between [00] and [01].
 const MV6_FEAT_POPPER_STOPPER: [u8; 2] = [0x03, 0x81];
 /// MV6 mute button disable. Address [0x0C, 0x00] confirmed by Wireshark capture.
-/// SET uses cmd [02 02 01], HDR_CONSTANT=0x00, inverted encoding (0x00=disabled, 0x01=active).
-/// State is persisted host-side in mv6_state.toml since GET is unreliable.
+/// SET uses cmd [02 02 01], HDR_CONSTANT=0x00, payload [addr_hi, addr_lo, 0x60, enable_byte].
+/// GET uses cmd [01 02 01], HDR_CONSTANT=0x03, payload [addr_hi, addr_lo, 0x60].
+/// In both GET and SET the address bytes appear at payload[0..2] with 0x60 at payload[2],
+/// so parse_response sees feat_addr=[0x00, 0x60] and value at the following byte.
+/// enable_byte: 0x00=disabled, 0x01=active (inverted). GET confirmed reliable by Wireshark.
 const MV6_FEAT_MUTE_BTN_DISABLE: [u8; 2] = [0x0C, 0x00];
+/// The feature address as seen by parse_response for mute button disable GET/SET responses.
+/// Because the payload layout puts [addr_hi=0x0C, addr_lo=0x00, mix=0x60] at bytes 13–15,
+/// parse_response reads feat_addr from bytes 14–15 as [0x00, 0x60].
+const MV6_FEAT_MUTE_BTN_DISABLE_RESP: [u8; 2] = [0x00, 0x60];
 /// MV6 tone character. 16-bit signed big-endian, units: percent.
 /// Range: -100 (Dark) to +100 (Bright) in steps of 10. 0 = Natural (default).
 const MV6_FEAT_TONE: [u8; 2] = [0x02, 0x04];
@@ -235,7 +255,7 @@ pub struct DeviceState {
     /// Popper stopper. MV6 only. Address [0x03, 0x81] confirmed by MOTIV app probe diff.
     pub popper_stopper_enabled: bool,
     /// Mute button disable. MV6 only. Address [0x0C, 0x00] confirmed by Wireshark capture.
-    /// State persisted host-side in mv6_state.toml; see presets::Mv6State.
+    /// GET uses CMD_GET_LOCK with inverted encoding; read from device at startup.
     pub mute_btn_disabled: bool,
     /// Tone character. MV6 only. Range: -10 to +10 (displayed as × 10%).
     /// -10 = 100% Dark, 0 = Natural, +10 = 100% Bright.
@@ -742,6 +762,27 @@ pub fn cmd_get_mv6_tone(seq: u8) -> Vec<u8> {
 pub fn cmd_get_mv6_gain_lock(seq: u8) -> Vec<u8> {
     cmd_get(seq, &MV6_FEAT_GAIN_LOCK)
 }
+/// GET for MV6 monitor mix. Uses standard framing (HDR_CONSTANT=0x03, prefix=0x00).
+/// Confirmed by Wireshark capture. Note: the device only responds after at least one
+/// SET has been issued — a fresh device returns nothing, which is why the probe sweep
+/// found no response before shurectl first wrote a value.
+pub fn cmd_get_mv6_mix(seq: u8) -> Vec<u8> {
+    cmd_get(seq, &FEAT_MIX)
+}
+
+/// GET for MV6 mute button disable state.
+/// Uses CMD_GET_LOCK class with payload [addr_hi=0x0C, addr_lo=0x00, mix_byte=0x60].
+/// parse_response will return feat_addr=[0x00, 0x60] (MV6_FEAT_MUTE_BTN_DISABLE_RESP)
+/// with value[0]: 0x00=button disabled, 0x01=button active (inverted encoding).
+/// Confirmed reliable by Wireshark — device correctly reflects current state.
+pub fn cmd_get_mv6_mute_btn_disable(seq: u8) -> Vec<u8> {
+    let payload = [
+        MV6_FEAT_MUTE_BTN_DISABLE[0],
+        MV6_FEAT_MUTE_BTN_DISABLE[1],
+        0x60,
+    ];
+    build_packet(seq, &CMD_GET_LOCK, &payload)
+}
 
 // ── Lock command constructors ─────────────────────────────────────────────────
 //
@@ -922,6 +963,42 @@ pub fn cmd_set_mv6_mute_btn_disable(seq: u8, disabled: bool) -> Vec<u8> {
     pkt
 }
 
+/// Set the MV6 monitor mix level.
+///
+/// `mix` is clamped to 0–100: 0 = full mic in headphones, 100 = full playback.
+/// Uses the same FEAT_MIX address as the MVX2U [0x01, 0x86], but requires
+/// HDR_CONSTANT=0x00 (confirmed by Wireshark capture of MOTIV app SET packet).
+/// GET uses standard framing — see cmd_get_mv6_mix().
+pub fn cmd_set_mv6_mix(seq: u8, mix: u8) -> Vec<u8> {
+    let value = mix.min(100);
+    let payload = [0x00, FEAT_MIX[0], FEAT_MIX[1], value];
+    let data_len = (3 + payload.len() + 2) as u8;
+
+    let mut inner: Vec<u8> = Vec::with_capacity(PACKET_SIZE);
+    inner.push(HEADER_MAGIC[0]);
+    inner.push(HEADER_MAGIC[1]);
+    inner.push(seq);
+    inner.push(0x00); // HDR_CONSTANT: 0x00 (confirmed by Wireshark; not the usual 0x03)
+    inner.push(HDR_END);
+    inner.push(data_len);
+    inner.push(DATA_START);
+    inner.push(data_len);
+    inner.extend_from_slice(&CMD_SET_FEAT);
+    inner.extend_from_slice(&payload);
+
+    let total_len = (inner.len() + 2) as u8;
+    let crc = crc16_ansi(&inner);
+
+    let mut pkt: Vec<u8> = Vec::with_capacity(PACKET_SIZE);
+    pkt.push(REPORT_ID);
+    pkt.push(total_len);
+    pkt.extend_from_slice(&inner);
+    pkt.push((crc >> 8) as u8);
+    pkt.push((crc & 0xFF) as u8);
+    pkt.resize(PACKET_SIZE, 0x00);
+    pkt
+}
+
 /// Set the MV6 tone character.
 /// `tone` is clamped to −10..+10 and encoded as `tone * 10` in 16-bit signed big-endian.
 /// -10 = 100% Dark, 0 = Natural, +10 = 100% Bright.
@@ -1059,11 +1136,12 @@ pub fn apply_response(feat_addr: [u8; 2], value: &[u8], state: &mut DeviceState)
             state.popper_stopper_enabled = value[0] != 0;
             true
         }
-        f if f == MV6_FEAT_MUTE_BTN_DISABLE => {
+        f if f == MV6_FEAT_MUTE_BTN_DISABLE_RESP => {
             if value.is_empty() {
                 return false;
             }
-            state.mute_btn_disabled = value[0] != 0;
+            // Inverted encoding: 0x00=button disabled, 0x01=button active.
+            state.mute_btn_disabled = value[0] == 0x00;
             true
         }
         f if f == MV6_FEAT_TONE => {
@@ -1291,6 +1369,59 @@ mod tests {
     fn set_mix_clamps_at_100() {
         let pkt = cmd_set_mix(0, 200);
         assert_eq!(pkt[16], 100);
+    }
+
+    // ── MV6 monitor mix ───────────────────────────────────────────────────────
+
+    #[test]
+    fn mv6_get_mix_uses_standard_framing() {
+        // Confirmed by Wireshark: GET uses HDR_CONSTANT=0x03 and prefix=0x00.
+        let pkt = cmd_get_mv6_mix(0);
+        assert_eq!(pkt.len(), PACKET_SIZE);
+        assert_eq!(pkt[5], 0x03, "GET must use standard HDR_CONSTANT=0x03");
+        assert_eq!(&pkt[10..13], &CMD_GET_FEAT, "must use CMD_GET_FEAT");
+        assert_eq!(pkt[13], 0x00, "prefix must be 0x00");
+        assert_eq!(&pkt[14..16], &FEAT_MIX, "must use FEAT_MIX address");
+    }
+
+    #[test]
+    fn mv6_set_mix_uses_hdr_constant_zero() {
+        // Confirmed by Wireshark capture: HDR_CONSTANT must be 0x00, not 0x03.
+        let pkt = cmd_set_mv6_mix(0, 62);
+        assert_eq!(pkt[5], 0x00, "HDR_CONSTANT must be 0x00 for MV6 mix SET");
+    }
+
+    #[test]
+    fn mv6_set_mix_uses_feat_mix_address() {
+        let pkt = cmd_set_mv6_mix(0, 50);
+        assert_eq!(&pkt[10..13], &CMD_SET_FEAT, "must use CMD_SET_FEAT");
+        assert_eq!(pkt[13], 0x00, "prefix must be 0x00");
+        assert_eq!(&pkt[14..16], &FEAT_MIX, "must use FEAT_MIX address");
+        assert_eq!(pkt[16], 50, "value must be encoded directly");
+    }
+
+    #[test]
+    fn mv6_set_mix_clamps_at_100() {
+        let pkt = cmd_set_mv6_mix(0, 200);
+        assert_eq!(pkt[16], 100, "must clamp to 100");
+    }
+
+    #[test]
+    fn mv6_set_mix_confirmed_capture_value() {
+        // Wireshark capture showed value 0x3e (62) when MOTIV mic level was 62%.
+        let pkt = cmd_set_mv6_mix(0, 62);
+        assert_eq!(pkt[16], 0x3e, "62% must encode as 0x3e");
+    }
+
+    #[test]
+    fn mv6_set_mix_has_valid_crc() {
+        for mix in [0u8, 41, 62, 100] {
+            let pkt = cmd_set_mv6_mix(0, mix);
+            let total_len = pkt[1] as usize;
+            let stored_crc = ((pkt[total_len] as u16) << 8) | pkt[total_len + 1] as u16;
+            let computed_crc = crc16_ansi(&pkt[2..total_len]);
+            assert_eq!(stored_crc, computed_crc, "CRC must be valid for mix={mix}");
+        }
     }
 
     #[test]
@@ -2132,18 +2263,47 @@ mod tests {
     }
 
     #[test]
+    fn mv6_mute_btn_disable_get_packet_structure() {
+        // GET confirmed by Wireshark: cmd=[01 02 01] (CMD_GET_LOCK), HDR_CONSTANT=0x03,
+        // payload=[0x0C, 0x00, 0x60]. parse_response sees feat_addr=[0x00, 0x60].
+        let pkt = cmd_get_mv6_mute_btn_disable(0);
+        assert_eq!(pkt.len(), PACKET_SIZE);
+        assert_eq!(pkt[5], 0x03, "GET must use standard HDR_CONSTANT=0x03");
+        assert_eq!(&pkt[10..13], &CMD_GET_LOCK, "must use CMD_GET_LOCK");
+        assert_eq!(
+            pkt[13], MV6_FEAT_MUTE_BTN_DISABLE[0],
+            "addr_hi must be 0x0C"
+        );
+        assert_eq!(
+            pkt[14], MV6_FEAT_MUTE_BTN_DISABLE[1],
+            "addr_lo must be 0x00"
+        );
+        assert_eq!(pkt[15], 0x60, "mix_byte must be 0x60");
+    }
+
+    #[test]
     fn mv6_mute_btn_disable_apply_response_roundtrip() {
-        for (bytes, expected) in [(&[0x00u8][..], false), (&[0x01u8][..], true)] {
+        // Response uses inverted encoding: 0x00=disabled, 0x01=active.
+        // feat_addr in response is MV6_FEAT_MUTE_BTN_DISABLE_RESP=[0x00, 0x60].
+        for (bytes, expected_disabled) in [(&[0x00u8][..], true), (&[0x01u8][..], false)] {
             let mut state = DeviceState::default();
-            assert!(apply_response(MV6_FEAT_MUTE_BTN_DISABLE, bytes, &mut state));
-            assert_eq!(state.mute_btn_disabled, expected);
+            assert!(apply_response(
+                MV6_FEAT_MUTE_BTN_DISABLE_RESP,
+                bytes,
+                &mut state
+            ));
+            assert_eq!(state.mute_btn_disabled, expected_disabled);
         }
     }
 
     #[test]
     fn mv6_mute_btn_disable_apply_response_empty_returns_false() {
         let mut state = DeviceState::default();
-        assert!(!apply_response(MV6_FEAT_MUTE_BTN_DISABLE, &[], &mut state));
+        assert!(!apply_response(
+            MV6_FEAT_MUTE_BTN_DISABLE_RESP,
+            &[],
+            &mut state
+        ));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -216,6 +216,7 @@ fn draw_main_left_mv6_manual(f: &mut Frame, app: &App, area: Rect) {
             Constraint::Length(3), // gain gauge
             Constraint::Length(3), // gain lock
             Constraint::Length(4), // level meter
+            Constraint::Length(3), // monitor mix
             Constraint::Min(0),    // spacer
         ])
         .margin(1)
@@ -317,6 +318,7 @@ fn draw_main_left_mv6_manual(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(gain_lock_p, rows[3]);
 
     draw_meter(f, app, rows[4]);
+    draw_monitor_mix_gauge(f, app, rows[5]);
 }
 
 fn draw_main_left_mv6_auto(f: &mut Frame, app: &App, area: Rect) {
@@ -326,6 +328,7 @@ fn draw_main_left_mv6_auto(f: &mut Frame, app: &App, area: Rect) {
             Constraint::Length(3), // mode
             Constraint::Length(3), // mute
             Constraint::Length(4), // level meter
+            Constraint::Length(3), // monitor mix
             Constraint::Min(0),    // spacer
         ])
         .margin(1)
@@ -334,6 +337,7 @@ fn draw_main_left_mv6_auto(f: &mut Frame, app: &App, area: Rect) {
     draw_mode_block(f, app, rows[0]);
     draw_mute_block(f, app, rows[1]);
     draw_meter(f, app, rows[2]);
+    draw_monitor_mix_gauge(f, app, rows[3]);
 }
 
 fn draw_main_left_manual(f: &mut Frame, app: &App, area: Rect) {
@@ -619,25 +623,9 @@ fn draw_mute_block(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(p, area);
 }
 
-/// Renders the controls shared by both Manual and Auto layouts that follow
-/// the mode-specific top section: Level Meter, Monitor Mix, Phantom Power,
-/// Config Lock.
-///
-/// Control order follows the signal chain: observe the level produced by the
-/// gain you just set, adjust monitoring, then the rarely-changed setup
-/// controls (phantom, lock) at the bottom.
-///
-/// `rows` must have at least 4 elements (indices 0–3).
-fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
-    assert!(
-        rows.len() >= 4,
-        "draw_main_shared requires at least 4 row slots, got {}",
-        rows.len()
-    );
-    // ── Level Meter ───────────────────────────────────────────────────────────
-    draw_meter(f, app, rows[0]);
-
-    // ── Monitor Mix ───────────────────────────────────────────────────────────
+/// Renders the monitor mix gauge. Used by both MVX2U (via draw_main_shared)
+/// and MV6 (directly in draw_main_left_mv6_manual / draw_main_left_mv6_auto).
+fn draw_monitor_mix_gauge(f: &mut Frame, app: &App, area: Rect) {
     let mm_focused = app.focus == Focus::MonitorMix;
     let mix = app.device_state.monitor_mix;
     let mix_gauge = Gauge::default()
@@ -662,7 +650,29 @@ fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
         .gauge_style(Style::default().fg(Color::Rgb(50, 150, 220)).bg(C_SURFACE))
         .ratio(mix as f64 / 100.0)
         .label(format!("Mic ◄─{:3}%─► Playback", mix));
-    f.render_widget(mix_gauge, rows[1]);
+    f.render_widget(mix_gauge, area);
+}
+
+/// Renders the controls shared by both Manual and Auto layouts that follow
+/// the mode-specific top section: Level Meter, Monitor Mix, Phantom Power,
+/// Config Lock.
+///
+/// Control order follows the signal chain: observe the level produced by the
+/// gain you just set, adjust monitoring, then the rarely-changed setup
+/// controls (phantom, lock) at the bottom.
+///
+/// `rows` must have at least 4 elements (indices 0–3).
+fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
+    assert!(
+        rows.len() >= 4,
+        "draw_main_shared requires at least 4 row slots, got {}",
+        rows.len()
+    );
+    // ── Level Meter ───────────────────────────────────────────────────────────
+    draw_meter(f, app, rows[0]);
+
+    // ── Monitor Mix ───────────────────────────────────────────────────────────
+    draw_monitor_mix_gauge(f, app, rows[1]);
 
     // ── Phantom Power ─────────────────────────────────────────────────────────
     let ph_focused = app.focus == Focus::Phantom;


### PR DESCRIPTION
…istence

Add monitor mix slider to the MV6 Main tab (both Manual and Auto modes), confirmed by Wireshark capture of MOTIV app HID packets.

Protocol findings:
- Monitor mix uses FEAT_MIX [0x01, 0x86] — same address as MVX2U
- SET requires HDR_CONSTANT=0x00 (not the usual 0x03)
- GET uses standard framing; device only responds after first SET, which explains why the full probe sweep returned nothing
- Mute button disable GET uses CMD_GET_LOCK with payload [0x0C, 0x00, 0x60]; parse_response sees feat_addr=[0x00, 0x60] due to payload layout shift
- Mute button disable GET is reliable — inverted encoding confirmed (0x00=disabled, 0x01=active) by Wireshark capture of both states

Changes:
- protocol.rs: add cmd_get_mv6_mix, cmd_get_mv6_mute_btn_disable, cmd_set_mv6_mix; add MV6_FEAT_MUTE_BTN_DISABLE_RESP constant; fix apply_response mute_btn_disable branch (address and encoding); document all MV6 protocol quirks
- device.rs: add set_mv6_monitor_mix; add both new getters to get_state_mv6()
- app.rs: add Focus::MonitorMix to MV6 Manual and Auto cycles; dispatch SetMv6MonitorMix vs SetMonitorMix by model; step size 1%
- ui.rs: add monitor mix gauge to both MV6 draw functions; extract draw_monitor_mix_gauge helper shared with MVX2U
- presets.rs: remove Mv6State, load_mv6_state, save_mv6_state entirely
- main.rs: remove all mv6_state.toml read/write; mute button disable and monitor mix now read from device at startup like all other features

~/.config/shurectl/mv6_state.toml is now unused and can be deleted