### PR TITLE
 feat: add MVX2U Gen 2 support (PID 0x1033)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shurectl"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shurectl"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 description = "shurectl — TUI configurator for the Shure MVX2U audio interface"
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ interfaces and microphones on Linux and macOS. Replaces the Windows/Mac-only Shu
 ---
 
 ## Supported Devices
-- MVX2U Gen 1 - Digital Audio Interface
-- MV6 - USB Gaming Microphone
+- MVX2U Gen 1 — Digital Audio Interface
+- MVX2U Gen 2 — Digital Audio Interface
+- MV6 — USB Gaming Microphone
 
 ---
 
@@ -26,13 +27,20 @@ interfaces and microphones on Linux and macOS. Replaces the Windows/Mac-only Shu
 - **Device Info** — serial number
 - **Demo mode** — run without a device plugged in (`--demo`)
 
-### MVX2U
+### MVX2U Gen 1
 - **Gain range** — 0–60 dB
 - **Phantom Power** — 48V on/off; warns if enabled when muting ribbon mics
 - **5-band Parametric EQ** — per-band enable, gain (−8 to +6 dB in 2 dB steps)
 - **Limiter** — enable/disable
 - **Panel Lock** — lock the physical panel controls on the device
 - **Auto Level controls** — mic position (Near/Far), tone (Dark/Natural/Bright), gain environment (Quiet/Normal/Loud)
+
+### MVX2U Gen 2 -  Builds on Gen 1 features with the following
+- **5-band Parametric EQ** — gain (−8 to +6 dB in 0.5 dB steps)
+- **Tone** — Dark / Natural / Bright
+- **Real-time Denoiser** — enable/disable
+- **Popper Stopper** — enable/disable
+- **Gain Lock** — hardware freeze of the gain control (Manual mode only)
 
 ### MV6
 - **Gain range** — 0–36 dB
@@ -46,18 +54,15 @@ interfaces and microphones on Linux and macOS. Replaces the Windows/Mac-only Shu
 
 ## Platform Setup
 
-### Linux — udev Rule (Required for Non-Root Access)
+### Linux — udev Rules (Required for Non-Root Access)
 
 Without a udev rule, `/dev/hidrawN` for the device is only accessible by root.
 
-Create `/etc/udev/rules.d/62-mvx2u.rules`:
+Create `/etc/udev/rules.d/62-shurectl.rules`:
 
 ```
 ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"
-```
-Create `/etc/udev/rules.d/62-mv6.rules`:
-
-```
+ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1033", TAG+="uaccess"
 ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1026", TAG+="uaccess"
 ```
 
@@ -72,13 +77,8 @@ Verify the device appears:
 
 ```bash
 shurectl --list
-# Found 1 MVX2U device(s):
-#   /dev/hidraw2 | S/N: MVX2U-XXXXXXXX
-
-# With multiple devices:
-# Found 2 MVX2U device(s):
-#   /dev/hidraw3 | S/N: MVX2U#3-7d84d19...
-#   /dev/hidraw2 | S/N: MVX2U#3-17b7a6c...
+# Found 1 Shure device(s):
+#   /dev/hidraw2 | Shure MVX2U Gen 2 | S/N: MVX2U GEN 2#2-a646351d...
 ```
 
 ### macOS — No Extra Setup Required
@@ -139,6 +139,7 @@ shurectl --list                  # List detected Shure devices and exit
 | `←` / `h` | Decrease value |
 | `→` / `l` | Increase value |
 | `Enter` / `Space` | Toggle boolean / cycle option |
+| `f` | Flatten EQ (zero all bands) — EQ tab, Gen 1 and Gen 2 only |
 | `r` | Refresh state from device |
 | `s` | Save preset (on Presets tab, focused slot) |
 | `d` | Delete preset (on Presets tab, focused slot) |

--- a/src/app.rs
+++ b/src/app.rs
@@ -205,10 +205,22 @@ impl App {
                 InputMode::Manual => Focus::Gain,
                 InputMode::Auto => Focus::Mode,
             },
+            (Tab::Main, DeviceModel::Mvx2uGen2) => match self.device_state.mode {
+                InputMode::Manual => Focus::Gain,
+                InputMode::Auto => Focus::Mode,
+            },
             (Tab::Eq, DeviceModel::Mv6) => Focus::Tone,
             (Tab::Eq, DeviceModel::Mvx2u) => Focus::EqEnable,
+            (Tab::Eq, DeviceModel::Mvx2uGen2) => match self.device_state.mode {
+                InputMode::Auto => Focus::Tone,
+                InputMode::Manual => Focus::EqBandSelect,
+            },
             (Tab::Dynamics, DeviceModel::Mv6) => Focus::Denoiser,
             (Tab::Dynamics, DeviceModel::Mvx2u) => Focus::Limiter,
+            (Tab::Dynamics, DeviceModel::Mvx2uGen2) => match self.device_state.mode {
+                InputMode::Auto => Focus::Denoiser,
+                InputMode::Manual => Focus::Limiter,
+            },
             (Tab::Presets, _) => Focus::PresetName(0),
             (Tab::Info, _) => Focus::None,
         };
@@ -264,6 +276,57 @@ impl App {
 
             // ── MV6 EQ (Tone only) ────────────────────────────────────────────
             (Tab::Eq, _, DeviceModel::Mv6, _) => Focus::Tone,
+
+            // ── MVX2U Gen 2 Main cycle ────────────────────────────────────────
+            (Tab::Main, Focus::Mode, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Mute,
+            (Tab::Main, Focus::Mute, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, Focus::Gain, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::GainLock,
+            (Tab::Main, Focus::GainLock, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::MonitorMix
+            }
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::Phantom
+            }
+            (Tab::Main, Focus::Phantom, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Mode,
+            (Tab::Main, Focus::Mode, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::Mute, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::MonitorMix,
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mvx2uGen2, InputMode::Auto) => {
+                Focus::Phantom
+            }
+            (Tab::Main, Focus::Phantom, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, _, DeviceModel::Mvx2uGen2, _) => Focus::Mode,
+
+            // ── MVX2U Gen 2 EQ (Tone in Auto, 5-band in Manual) ──────────────
+            (Tab::Eq, _, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Tone,
+            (Tab::Eq, Focus::EqBandSelect, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::EqGain(self.eq_selected_band)
+            }
+            (Tab::Eq, Focus::EqGain(_), DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::EqBandSelect
+            }
+            (Tab::Eq, _, DeviceModel::Mvx2uGen2, _) => Focus::EqBandSelect,
+
+            // ── MVX2U Gen 2 Dynamics ──────────────────────────────────────────
+            (Tab::Dynamics, Focus::Limiter, DeviceModel::Mvx2uGen2, _) => Focus::Compressor,
+            (Tab::Dynamics, Focus::Compressor, DeviceModel::Mvx2uGen2, _) => Focus::Denoiser,
+            (Tab::Dynamics, Focus::Denoiser, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::PopperStopper
+            }
+            (Tab::Dynamics, Focus::PopperStopper, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::Hpf
+            }
+            (Tab::Dynamics, Focus::Hpf, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::Limiter
+            }
+            (Tab::Dynamics, Focus::Denoiser, DeviceModel::Mvx2uGen2, InputMode::Auto) => {
+                Focus::PopperStopper
+            }
+            (Tab::Dynamics, Focus::PopperStopper, DeviceModel::Mvx2uGen2, InputMode::Auto) => {
+                Focus::Hpf
+            }
+            (Tab::Dynamics, Focus::Hpf, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Denoiser,
+            (Tab::Dynamics, _, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Limiter,
+            (Tab::Dynamics, _, DeviceModel::Mvx2uGen2, _) => Focus::Denoiser,
 
             // ── MVX2U EQ ──────────────────────────────────────────────────────
             (Tab::Eq, Focus::EqEnable, DeviceModel::Mvx2u, _) => Focus::EqBandSelect,
@@ -337,6 +400,57 @@ impl App {
             // ── MV6 EQ ────────────────────────────────────────────────────────
             (Tab::Eq, _, DeviceModel::Mv6, _) => Focus::Tone,
 
+            // ── MVX2U Gen 2 Main reverse ──────────────────────────────────────
+            (Tab::Main, Focus::Mode, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Phantom,
+            (Tab::Main, Focus::Mute, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Mode,
+            (Tab::Main, Focus::Gain, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Mute,
+            (Tab::Main, Focus::GainLock, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Gain,
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::GainLock
+            }
+            (Tab::Main, Focus::Phantom, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::MonitorMix
+            }
+            (Tab::Main, Focus::Mode, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Phantom,
+            (Tab::Main, Focus::Mute, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Mode,
+            (Tab::Main, Focus::MonitorMix, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Mute,
+            (Tab::Main, Focus::Phantom, DeviceModel::Mvx2uGen2, InputMode::Auto) => {
+                Focus::MonitorMix
+            }
+            (Tab::Main, _, DeviceModel::Mvx2uGen2, _) => Focus::Mode,
+
+            // ── MVX2U Gen 2 EQ reverse ────────────────────────────────────────
+            (Tab::Eq, _, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Tone,
+            (Tab::Eq, Focus::EqBandSelect, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::EqGain(self.eq_selected_band)
+            }
+            (Tab::Eq, Focus::EqGain(_), DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::EqBandSelect
+            }
+            (Tab::Eq, _, DeviceModel::Mvx2uGen2, _) => Focus::EqBandSelect,
+
+            // ── MVX2U Gen 2 Dynamics reverse ──────────────────────────────────
+            (Tab::Dynamics, Focus::Limiter, DeviceModel::Mvx2uGen2, _) => Focus::Hpf,
+            (Tab::Dynamics, Focus::Compressor, DeviceModel::Mvx2uGen2, _) => Focus::Limiter,
+            (Tab::Dynamics, Focus::Denoiser, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::Compressor
+            }
+            (Tab::Dynamics, Focus::PopperStopper, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::Denoiser
+            }
+            (Tab::Dynamics, Focus::Hpf, DeviceModel::Mvx2uGen2, InputMode::Manual) => {
+                Focus::PopperStopper
+            }
+            (Tab::Dynamics, Focus::Denoiser, DeviceModel::Mvx2uGen2, InputMode::Auto) => Focus::Hpf,
+            (Tab::Dynamics, Focus::PopperStopper, DeviceModel::Mvx2uGen2, InputMode::Auto) => {
+                Focus::Denoiser
+            }
+            (Tab::Dynamics, Focus::Hpf, DeviceModel::Mvx2uGen2, InputMode::Auto) => {
+                Focus::PopperStopper
+            }
+            (Tab::Dynamics, _, DeviceModel::Mvx2uGen2, InputMode::Manual) => Focus::Limiter,
+            (Tab::Dynamics, _, DeviceModel::Mvx2uGen2, _) => Focus::Denoiser,
+
             // ── MVX2U EQ reverse ──────────────────────────────────────────────
             (Tab::Eq, Focus::EqEnable, DeviceModel::Mvx2u, _) => {
                 Focus::EqGain(self.eq_selected_band)
@@ -389,10 +503,11 @@ impl App {
                     *m = m.saturating_sub(1);
                 }
                 let mix = self.device_state.monitor_mix;
-                if self.device_model == DeviceModel::Mv6 {
-                    Some(DeviceAction::SetMv6MonitorMix(mix))
-                } else {
-                    Some(DeviceAction::SetMonitorMix(mix))
+                match self.device_model {
+                    DeviceModel::Mv6 | DeviceModel::Mvx2uGen2 => {
+                        Some(DeviceAction::SetMv6MonitorMix(mix))
+                    }
+                    DeviceModel::Mvx2u => Some(DeviceAction::SetMonitorMix(mix)),
                 }
             }
             Focus::Tone => {
@@ -409,8 +524,12 @@ impl App {
                 None
             }
             Focus::EqGain(b) => {
+                let step: i32 = match self.device_model {
+                    DeviceModel::Mvx2uGen2 => 5, // 0.5 dB steps
+                    _ => 20,                     // 2.0 dB steps
+                };
                 let band = &mut self.device_state.eq_bands[b];
-                let new_gain = ((band.gain_db as i32) + delta * 2).clamp(-8, 6) as i8;
+                let new_gain = ((band.gain_db as i32) + delta * step).clamp(-80, 60) as i16;
                 band.gain_db = new_gain;
                 Some(DeviceAction::SetEqBandGain(b, band.gain_db))
             }
@@ -426,9 +545,10 @@ impl App {
                     InputMode::Auto => InputMode::Manual,
                     InputMode::Manual => InputMode::Auto,
                 };
-                self.focus = match self.device_state.mode {
-                    InputMode::Auto => Focus::AutoPosition,
-                    InputMode::Manual => Focus::Gain,
+                self.focus = match (self.device_model, self.device_state.mode) {
+                    (DeviceModel::Mvx2u, InputMode::Auto) => Focus::AutoPosition,
+                    (_, InputMode::Manual) => Focus::Gain,
+                    (_, InputMode::Auto) => Focus::Mute,
                 };
                 Some(DeviceAction::SetMode(self.device_state.mode))
             }
@@ -537,8 +657,9 @@ pub enum DeviceAction {
     SetEqEnable(bool),
     /// `usize` is band index 0–4.
     SetEqBandEnable(usize, bool),
-    /// `usize` is band index 0–4; `i8` is gain in dB (−8..+6, steps of 2).
-    SetEqBandGain(usize, i8),
+    /// `usize` is band index 0–4; `i16` is gain in tenths of dB (−80..+60).
+    /// Gen 1 steps: multiples of 20. Gen 2 steps: multiples of 5.
+    SetEqBandGain(usize, i16),
     // ── MV6-specific actions ──────────────────────────────────────────────────
     SetMv6Denoiser(bool),
     SetMv6PopperStopper(bool),
@@ -555,6 +676,8 @@ pub enum DeviceAction {
     DeletePreset(usize),
     /// Write the (already in-memory-updated) preset name for slot `usize` back to disk.
     PersistPresetName(usize),
+    /// Zero all 5 EQ band gains. Gen 1: leaves EQ master and per-band enables untouched.
+    FlattenEq,
     Refresh,
 }
 
@@ -987,6 +1110,20 @@ mod tests {
     }
 
     #[test]
+    fn adjust_monitor_mix_dispatches_set_mv6_monitor_mix_for_gen2() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mvx2uGen2;
+        app.focus = Focus::MonitorMix;
+        app.device_state.monitor_mix = 50;
+
+        let action = app.adjust_focused(1);
+        assert!(
+            matches!(action, Some(DeviceAction::SetMv6MonitorMix(51))),
+            "Gen 2 must dispatch SetMv6MonitorMix (same wire framing), got {action:?}"
+        );
+    }
+
+    #[test]
     fn adjust_eq_band_select_cycles_through_five_bands() {
         let mut app = App::default();
         app.active_tab = Tab::Eq;
@@ -1005,36 +1142,57 @@ mod tests {
     }
 
     #[test]
-    fn adjust_eq_gain_clamps_at_plus_six_and_minus_eight() {
+    fn adjust_eq_gain_clamps_at_plus_sixty_and_minus_eighty_tenths() {
+        // Gen 1: steps of 20 tenths (2.0 dB)
         let mut app = App::default();
         app.active_tab = Tab::Eq;
         app.focus = Focus::EqGain(0);
-        app.device_state.eq_bands[0].gain_db = 6;
+        app.device_state.eq_bands[0].gain_db = 60;
 
         app.adjust_focused(1);
         assert_eq!(
-            app.device_state.eq_bands[0].gain_db, 6,
-            "EQ gain must not exceed +6"
+            app.device_state.eq_bands[0].gain_db, 60,
+            "EQ gain must not exceed +60 tenths (+6.0 dB)"
         );
 
-        app.device_state.eq_bands[0].gain_db = -8;
+        app.device_state.eq_bands[0].gain_db = -80;
         app.adjust_focused(-1);
         assert_eq!(
-            app.device_state.eq_bands[0].gain_db, -8,
-            "EQ gain must not go below -8"
+            app.device_state.eq_bands[0].gain_db, -80,
+            "EQ gain must not go below -80 tenths (-8.0 dB)"
         );
     }
 
     #[test]
-    fn adjust_eq_gain_steps_by_two_and_returns_action() {
+    fn adjust_eq_gain_gen1_steps_by_twenty_tenths() {
         let mut app = App::default();
+        app.device_model = DeviceModel::Mvx2u;
         app.active_tab = Tab::Eq;
         app.focus = Focus::EqGain(2);
         app.device_state.eq_bands[2].gain_db = 0;
 
         let action = app.adjust_focused(1);
-        assert_eq!(app.device_state.eq_bands[2].gain_db, 2);
-        assert!(matches!(action, Some(DeviceAction::SetEqBandGain(2, 2))));
+        assert_eq!(
+            app.device_state.eq_bands[2].gain_db, 20,
+            "Gen 1 step must be 20 tenths"
+        );
+        assert!(matches!(action, Some(DeviceAction::SetEqBandGain(2, 20))));
+    }
+
+    #[test]
+    fn adjust_eq_gain_gen2_steps_by_five_tenths() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mvx2uGen2;
+        app.active_tab = Tab::Eq;
+        app.focus = Focus::EqGain(2);
+        app.device_state.eq_bands[2].gain_db = 0;
+
+        let action = app.adjust_focused(1);
+        assert_eq!(
+            app.device_state.eq_bands[2].gain_db, 5,
+            "Gen 2 step must be 5 tenths"
+        );
+        assert!(matches!(action, Some(DeviceAction::SetEqBandGain(2, 5))));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1557,6 +1557,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn mv6_dynamics_tab_focus_cycles_all_four_controls() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mv6;
+        app.active_tab = Tab::Dynamics;
+        app.focus = Focus::Denoiser;
+
+        // Forward: Denoiser → PopperStopper → MuteBtnDisable → Hpf → Denoiser
+        app.focus_next();
+        assert_eq!(app.focus, Focus::PopperStopper);
+        app.focus_next();
+        assert_eq!(app.focus, Focus::MuteBtnDisable);
+        app.focus_next();
+        assert_eq!(app.focus, Focus::Hpf);
+        app.focus_next();
+        assert_eq!(app.focus, Focus::Denoiser); // wrap
+
+        // Backward: Denoiser → Hpf → MuteBtnDisable → PopperStopper → Denoiser
+        app.focus_prev();
+        assert_eq!(app.focus, Focus::Hpf);
+        app.focus_prev();
+        assert_eq!(app.focus, Focus::MuteBtnDisable);
+        app.focus_prev();
+        assert_eq!(app.focus, Focus::PopperStopper);
+        app.focus_prev();
+        assert_eq!(app.focus, Focus::Denoiser); // wrap
+    }
+
     // ── preset focus / toggle ─────────────────────────────────────────────────
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -160,8 +160,10 @@ impl App {
 
     /// Returns true when a tab should be inaccessible given the current device state.
     ///
-    /// MVX2U: EQ and Dynamics are locked in Auto Level mode (device manages them).
-    /// MV6:   EQ (Tone) and Dynamics are always accessible.
+    /// MVX2U Gen 1: EQ and Dynamics are locked in Auto Level mode — the device
+    /// manages those parameters itself and rejects SETs while in Auto.
+    /// MVX2U Gen 2 and MV6: EQ and Dynamics are always accessible regardless of mode,
+    /// so only Gen 1 is gated here.
     pub fn is_tab_locked(&self, tab: Tab) -> bool {
         matches!(
             (tab, self.device_model, self.device_state.mode),
@@ -228,11 +230,25 @@ impl App {
 
     // ── Focus cycling within a tab ────────────────────────────────────────────
     //
-    // MVX2U Main cycles:
+    // MVX2U Gen 1 Main cycles:
     //   Manual: Mode → Mute → Gain → MonitorMix → Phantom → Lock → (wrap)
     //   Auto:   Mode → Mute → AutoPosition → AutoTone → AutoGain → MonitorMix → Phantom → Lock → (wrap)
     //
-    // MV6 Main cycles (mirrors MVX2U structure, no extra controls):
+    // MVX2U Gen 2 Main cycles:
+    //   Manual: Mode → Mute → Gain → GainLock → MonitorMix → Phantom → (wrap)
+    //   Auto:   Mode → Mute → MonitorMix → Phantom → (wrap)
+    //
+    // MVX2U Gen 2 EQ cycles:
+    //   Auto:   Tone (slider only)
+    //   Manual: EqBandSelect → EqGain(band) → (wrap)
+    //
+    // MVX2U Gen 2 Dynamics cycles:
+    //   Manual: Limiter → Compressor → Denoiser → PopperStopper → Hpf → (wrap)
+    //   Auto:   Denoiser → PopperStopper → Hpf → (wrap)
+    //   Note: if mode switches while Focus is on Limiter/Compressor (Manual-only),
+    //   the next focus_next/prev call self-corrects to Denoiser via the catchall arm.
+    //
+    // MV6 Main cycles:
     //   Manual: Mode → Mute → Gain → GainLock → MonitorMix → (wrap)
     //   Auto:   Mode → Mute → MonitorMix → (wrap)
     //

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,8 +1,9 @@
 //! Device I/O: wraps hidapi for Shure USB microphones.
 //!
-//! Supports two devices:
-//!   - Shure MVX2U (VID 0x14ED, PID 0x1013) — XLR-to-USB interface
-//!   - Shure MV6   (VID 0x14ED, PID 0x1026) — USB gaming microphone
+//! Supports three devices:
+//!   - Shure MVX2U       (VID 0x14ED, PID 0x1013) — XLR-to-USB interface (Gen 1)
+//!   - Shure MVX2U Gen 2 (VID 0x14ED, PID 0x1033) — XLR-to-USB interface (Gen 2)
+//!   - Shure MV6         (VID 0x14ED, PID 0x1026) — USB gaming microphone
 //!
 //! Both devices expose a USB HID configuration interface alongside their
 //! audio interface. hidapi opens the HID interface via /dev/hidrawN on Linux,
@@ -36,8 +37,8 @@ use anyhow::{Context, Result, anyhow};
 use hidapi::{HidApi, HidDevice};
 
 use crate::protocol::{
-    self, DeviceModel, DeviceState, MV6_PID, PACKET_SIZE, PID, VID, apply_response, cmd_confirm,
-    cmd_get_auto_gain, cmd_get_auto_position, cmd_get_auto_tone, cmd_get_compressor,
+    self, DeviceModel, DeviceState, MV6_PID, MVX2U_GEN2_PID, PACKET_SIZE, PID, VID, apply_response,
+    cmd_confirm, cmd_get_auto_gain, cmd_get_auto_position, cmd_get_auto_tone, cmd_get_compressor,
     cmd_get_eq_band_enable, cmd_get_eq_band_gain, cmd_get_eq_enable, cmd_get_gain, cmd_get_hpf,
     cmd_get_limiter, cmd_get_lock, cmd_get_mix, cmd_get_mode, cmd_get_mute, cmd_get_mv6_denoiser,
     cmd_get_mv6_gain_lock, cmd_get_mv6_mix, cmd_get_mv6_mute_btn_disable,
@@ -71,10 +72,10 @@ impl ShureDevice {
             .ok()
             .flatten()
             .unwrap_or_else(|| "(unknown)".to_string());
-        let model = if pid == MV6_PID {
-            DeviceModel::Mv6
-        } else {
-            DeviceModel::Mvx2u
+        let model = match pid {
+            MV6_PID => DeviceModel::Mv6,
+            MVX2U_GEN2_PID => DeviceModel::Mvx2uGen2,
+            _ => DeviceModel::Mvx2u,
         };
         Self {
             device,
@@ -101,7 +102,7 @@ impl ShureDevice {
 
         match found.len() {
             0 => Err(anyhow!(
-                "No Shure MVX2U or MV6 device found.\nHint: {ACCESS_HINT}."
+                "No Shure MVX2U, MVX2U Gen 2, or MV6 device found.\nHint: {ACCESS_HINT}."
             )),
             1 => {
                 let info = found[0];
@@ -131,14 +132,15 @@ impl ShureDevice {
             })?;
 
         let pid = info.product_id();
-        if info.vendor_id() != VID || (pid != PID && pid != MV6_PID) {
+        if info.vendor_id() != VID || (pid != PID && pid != MV6_PID && pid != MVX2U_GEN2_PID) {
             return Err(anyhow!(
                 "{path} is not a supported Shure device \
-                (VID={:#06x} PID={:#06x}); expected VID={:#06x} with PID={:#06x} or {:#06x}.",
+                (VID={:#06x} PID={:#06x}); expected VID={:#06x} with PID={:#06x}, {:#06x}, or {:#06x}.",
                 info.vendor_id(),
                 pid,
                 VID,
                 PID,
+                MVX2U_GEN2_PID,
                 MV6_PID,
             ));
         }
@@ -200,6 +202,7 @@ impl ShureDevice {
     pub fn get_state(&self) -> Result<DeviceState> {
         match self.model {
             DeviceModel::Mvx2u => self.get_state_mvx2u(),
+            DeviceModel::Mvx2uGen2 => self.get_state_mvx2u_gen2(),
             DeviceModel::Mv6 => self.get_state_mv6(),
         }
     }
@@ -246,6 +249,44 @@ impl ShureDevice {
             {
                 eprintln!(
                     "get_state: unrecognised feature {feat:#04x?} in EQ band {band} gain response"
+                );
+            }
+        }
+
+        Ok(state)
+    }
+
+    fn get_state_mvx2u_gen2(&self) -> Result<DeviceState> {
+        let mut state = DeviceState::default();
+
+        // Gen 2 shares most getters with Gen 1 but has no config lock, no EQ master
+        // enable, and no per-band enable. It adds denoiser, popper stopper, gain lock,
+        // tone, and uses the MV6-style monitor mix framing.
+        let getters: &[fn(u8) -> Vec<u8>] = &[
+            cmd_get_gain,
+            cmd_get_mute,
+            cmd_get_phantom,
+            cmd_get_mode,
+            cmd_get_mv6_mix, // same address as Gen 1 mix; GET uses standard framing
+            cmd_get_hpf,
+            cmd_get_limiter,
+            cmd_get_compressor,
+            cmd_get_mv6_denoiser,
+            cmd_get_mv6_popper_stopper,
+            cmd_get_mv6_tone,
+            cmd_get_mv6_gain_lock,
+        ];
+
+        self.run_getters(getters, &mut state, "get_state(mvx2u_gen2)");
+
+        // Gen 2 has 5-band EQ gain (no master enable, no per-band enable toggle).
+        for band in 0..5 {
+            let gain_pkt = cmd_get_eq_band_gain(self.next_seq(), band);
+            if let Ok(Some((feat, value))) = self.send_get(&gain_pkt)
+                && !apply_response(feat, &value, &mut state)
+            {
+                eprintln!(
+                    "get_state(mvx2u_gen2): unrecognised feature {feat:#04x?} in EQ band {band} gain response"
                 );
             }
         }
@@ -336,11 +377,12 @@ impl ShureDevice {
         ))
     }
 
-    pub fn set_eq_band_gain(&self, band: usize, gain_db: i8) -> Result<()> {
+    pub fn set_eq_band_gain(&self, band: usize, gain_tenths: i16) -> Result<()> {
         self.send_set(&protocol::cmd_set_eq_band_gain(
             self.next_seq(),
             band,
-            gain_db,
+            gain_tenths,
+            self.model,
         ))
     }
 
@@ -397,7 +439,7 @@ fn is_shure_device(
     seen_paths: &mut std::collections::HashSet<String>,
 ) -> bool {
     d.vendor_id() == VID
-        && (d.product_id() == PID || d.product_id() == MV6_PID)
+        && (d.product_id() == PID || d.product_id() == MVX2U_GEN2_PID || d.product_id() == MV6_PID)
         && seen_paths.insert(d.path().to_string_lossy().into_owned())
 }
 
@@ -412,10 +454,10 @@ pub fn list_devices() -> Vec<DeviceInfo> {
         .map(|d| DeviceInfo {
             path: d.path().to_string_lossy().into_owned(),
             serial: d.serial_number().unwrap_or("(unknown)").to_owned(),
-            model: if d.product_id() == MV6_PID {
-                DeviceModel::Mv6
-            } else {
-                DeviceModel::Mvx2u
+            model: match d.product_id() {
+                MV6_PID => DeviceModel::Mv6,
+                MVX2U_GEN2_PID => DeviceModel::Mvx2uGen2,
+                _ => DeviceModel::Mvx2u,
             },
         })
         .collect()

--- a/src/device.rs
+++ b/src/device.rs
@@ -186,6 +186,21 @@ impl ShureDevice {
         Ok(parse_response(&buf))
     }
 
+    /// Fetch all 5 EQ band gain values and apply them to `state`.
+    /// Used by both Gen 1 and Gen 2 state readback.
+    fn fetch_eq_band_gains(&self, state: &mut DeviceState, context: &str) {
+        for band in 0..5 {
+            let gain_pkt = cmd_get_eq_band_gain(self.next_seq(), band);
+            if let Ok(Some((feat, value))) = self.send_get(&gain_pkt)
+                && !apply_response(feat, &value, state)
+            {
+                eprintln!(
+                    "{context}: unrecognised feature {feat:#04x?} in EQ band {band} gain response"
+                );
+            }
+        }
+    }
+
     /// Send each getter, apply the response to `state`, and log any unrecognised features.
     fn run_getters(&self, getters: &[fn(u8) -> Vec<u8>], state: &mut DeviceState, context: &str) {
         for getter in getters {
@@ -243,15 +258,8 @@ impl ShureDevice {
                     "get_state: unrecognised feature {feat:#04x?} in EQ band {band} enable response"
                 );
             }
-            let gain_pkt = cmd_get_eq_band_gain(self.next_seq(), band);
-            if let Ok(Some((feat, value))) = self.send_get(&gain_pkt)
-                && !apply_response(feat, &value, &mut state)
-            {
-                eprintln!(
-                    "get_state: unrecognised feature {feat:#04x?} in EQ band {band} gain response"
-                );
-            }
         }
+        self.fetch_eq_band_gains(&mut state, "get_state");
 
         Ok(state)
     }
@@ -280,16 +288,7 @@ impl ShureDevice {
         self.run_getters(getters, &mut state, "get_state(mvx2u_gen2)");
 
         // Gen 2 has 5-band EQ gain (no master enable, no per-band enable toggle).
-        for band in 0..5 {
-            let gain_pkt = cmd_get_eq_band_gain(self.next_seq(), band);
-            if let Ok(Some((feat, value))) = self.send_get(&gain_pkt)
-                && !apply_response(feat, &value, &mut state)
-            {
-                eprintln!(
-                    "get_state(mvx2u_gen2): unrecognised feature {feat:#04x?} in EQ band {band} gain response"
-                );
-            }
-        }
+        self.fetch_eq_band_gains(&mut state, "get_state(mvx2u_gen2)");
 
         Ok(state)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ use protocol::{DeviceModel, InputMode};
 #[command(
     name = "shurectl",
     version,
-    about = "shurectl — TUI configurator for Shure MVX2U and MV6 USB microphones"
+    about = "shurectl — TUI configurator for Shure MVX2U, MVX2U Gen 2, and MV6 USB microphones"
 )]
 struct Cli {
     /// Run in demo mode without a real device
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
     if cli.list {
         let devs = device::list_devices();
         if devs.is_empty() {
-            println!("No Shure MVX2U or MV6 devices found.");
+            println!("No Shure MVX2U, MVX2U Gen 2, or MV6 devices found.");
             #[cfg(target_os = "linux")]
             println!("Check that the device is plugged in and the udev rule is installed.");
             #[cfg(not(target_os = "linux"))]
@@ -285,6 +285,7 @@ fn handle_key(app: &mut App, code: KeyCode, mods: KeyModifiers) -> Option<Device
                 None
             }
         }
+        KeyCode::Char('f') if app.active_tab == app::Tab::Eq => Some(DeviceAction::FlattenEq),
         KeyCode::Char('d') | KeyCode::Delete if app.active_tab == app::Tab::Presets => {
             if let app::Focus::PresetActions(i) = app.focus {
                 if app.presets[i].is_some() {
@@ -382,9 +383,22 @@ fn apply_action(app: &mut App, device: &Option<ShureDevice>, action: DeviceActio
             ));
             send_if_connected(device, |d| d.set_eq_band_enable(*band, *en))
         }
-        DeviceAction::SetEqBandGain(band, gain_db) => {
-            app.set_ok(format!("EQ Band {} → {:+} dB", band + 1, gain_db));
-            send_if_connected(device, |d| d.set_eq_band_gain(*band, *gain_db))
+        DeviceAction::SetEqBandGain(band, gain_tenths) => {
+            let db = *gain_tenths as f32 / 10.0;
+            app.set_ok(format!("EQ Band {} → {:+.1} dB", band + 1, db));
+            send_if_connected(device, |d| d.set_eq_band_gain(*band, *gain_tenths))
+        }
+        DeviceAction::FlattenEq => {
+            for band in app.device_state.eq_bands.iter_mut() {
+                band.gain_db = 0;
+            }
+            app.set_ok("EQ flattened.");
+            send_if_connected(device, |d| {
+                for band in 0..5 {
+                    d.set_eq_band_gain(band, 0)?;
+                }
+                Ok(())
+            })
         }
         // ── MV6 actions ───────────────────────────────────────────────────────
         DeviceAction::SetMv6Denoiser(en) => {
@@ -521,6 +535,19 @@ fn apply_preset_to_device(
                 d.set_eq_enable(state.eq_enabled)?;
                 for (band, eq) in state.eq_bands.iter().enumerate() {
                     d.set_eq_band_enable(band, eq.enabled)?;
+                    d.set_eq_band_gain(band, eq.gain_db)?;
+                }
+            }
+            DeviceModel::Mvx2uGen2 => {
+                d.set_phantom(state.phantom_power)?;
+                d.set_mv6_monitor_mix(state.monitor_mix)?;
+                d.set_limiter(state.limiter_enabled)?;
+                d.set_compressor(&state.compressor)?;
+                d.set_mv6_denoiser(state.denoiser_enabled)?;
+                d.set_mv6_popper_stopper(state.popper_stopper_enabled)?;
+                d.set_mv6_tone(state.tone)?;
+                d.set_mv6_gain_lock(state.mv6_gain_locked)?;
+                for (band, eq) in state.eq_bands.iter().enumerate() {
                     d.set_eq_band_gain(band, eq.gain_db)?;
                 }
             }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -126,6 +126,33 @@ impl PresetSlot {
         state.mv6_gain_locked = self.mv6_gain_locked;
     }
 
+    /// Format the denoiser state as a display string.
+    fn denoiser_str(&self) -> &'static str {
+        if self.denoiser_enabled {
+            "Denoiser on"
+        } else {
+            "Denoiser off"
+        }
+    }
+
+    /// Format the popper stopper state as a display string.
+    fn popper_str(&self) -> &'static str {
+        if self.popper_stopper_enabled {
+            "Popper on"
+        } else {
+            "Popper off"
+        }
+    }
+
+    /// Format the tone value as a display string.
+    fn tone_str(&self) -> String {
+        match self.tone {
+            0 => "Natural".to_string(),
+            t if t > 0 => format!("{}% Bright", t as i32 * 10),
+            t => format!("{}% Dark", (t as i32 * 10).abs()),
+        }
+    }
+
     /// One-line summary of the key settings for display in the TUI.
     ///
     /// The model is needed because MVX2U and MV6 have different configurable
@@ -139,21 +166,9 @@ impl PresetSlot {
 
         match model {
             DeviceModel::Mv6 => {
-                let denoiser_str = if self.denoiser_enabled {
-                    "Denoiser on"
-                } else {
-                    "Denoiser off"
-                };
-                let popper_str = if self.popper_stopper_enabled {
-                    "Popper on"
-                } else {
-                    "Popper off"
-                };
-                let tone_str = match self.tone {
-                    0 => "Natural".to_string(),
-                    t if t > 0 => format!("{}% Bright", t as i32 * 10),
-                    t => format!("{}% Dark", (t as i32 * 10).abs()),
-                };
+                let denoiser_str = self.denoiser_str();
+                let popper_str = self.popper_str();
+                let tone_str = self.tone_str();
                 format!(
                     "{}dB · {denoiser_str} · {popper_str} · {hpf_str} · Tone: {tone_str}",
                     self.gain_db
@@ -165,21 +180,9 @@ impl PresetSlot {
                 } else {
                     "48V off"
                 };
-                let denoiser_str = if self.denoiser_enabled {
-                    "Denoiser on"
-                } else {
-                    "Denoiser off"
-                };
-                let popper_str = if self.popper_stopper_enabled {
-                    "Popper on"
-                } else {
-                    "Popper off"
-                };
-                let tone_str = match self.tone {
-                    0 => "Natural".to_string(),
-                    t if t > 0 => format!("{}% Bright", t as i32 * 10),
-                    t => format!("{}% Dark", (t as i32 * 10).abs()),
-                };
+                let denoiser_str = self.denoiser_str();
+                let popper_str = self.popper_str();
+                let tone_str = self.tone_str();
                 match InputMode::from(self.mode) {
                     InputMode::Auto => {
                         format!(

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -159,6 +159,47 @@ impl PresetSlot {
                     self.gain_db
                 )
             }
+            DeviceModel::Mvx2uGen2 => {
+                let phantom_str = if self.phantom_power {
+                    "48V on"
+                } else {
+                    "48V off"
+                };
+                let denoiser_str = if self.denoiser_enabled {
+                    "Denoiser on"
+                } else {
+                    "Denoiser off"
+                };
+                let popper_str = if self.popper_stopper_enabled {
+                    "Popper on"
+                } else {
+                    "Popper off"
+                };
+                let tone_str = match self.tone {
+                    0 => "Natural".to_string(),
+                    t if t > 0 => format!("{}% Bright", t as i32 * 10),
+                    t => format!("{}% Dark", (t as i32 * 10).abs()),
+                };
+                match InputMode::from(self.mode) {
+                    InputMode::Auto => {
+                        format!(
+                            "Auto · {phantom_str} · {denoiser_str} · {popper_str} · Tone: {tone_str}"
+                        )
+                    }
+                    InputMode::Manual => {
+                        let comp_str = CompressorPreset::from(self.compressor).to_string();
+                        let limiter_str = if self.limiter_enabled {
+                            "Limiter on"
+                        } else {
+                            "Limiter off"
+                        };
+                        format!(
+                            "Manual · {}dB · {limiter_str} · Comp: {comp_str} · {phantom_str} · {denoiser_str} · {popper_str} · {hpf_str}",
+                            self.gain_db
+                        )
+                    }
+                }
+            }
             DeviceModel::Mvx2u => {
                 let phantom_str = if self.phantom_power {
                     "48V on"
@@ -450,8 +491,9 @@ impl From<SerHpfFrequency> for HpfFrequency {
 #[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 pub struct SerEqBand {
     pub enabled: bool,
-    /// Gain in dB, range −8..+6.
-    pub gain_db: i8,
+    /// Gain in tenths of dB, range −80..+60.
+    /// Stored as i16 so presets round-trip at 0.5 dB resolution for Gen 2.
+    pub gain_db: i16,
 }
 
 impl From<EqBand> for SerEqBand {
@@ -495,11 +537,11 @@ mod tests {
             eq_bands: [
                 EqBand {
                     enabled: true,
-                    gain_db: 4,
+                    gain_db: 40, // +4.0 dB in tenths
                 },
                 EqBand {
                     enabled: false,
-                    gain_db: -2,
+                    gain_db: -20, // -2.0 dB in tenths
                 },
                 EqBand {
                     enabled: true,
@@ -507,11 +549,11 @@ mod tests {
                 },
                 EqBand {
                     enabled: false,
-                    gain_db: 6,
+                    gain_db: 60, // +6.0 dB in tenths
                 },
                 EqBand {
                     enabled: true,
-                    gain_db: -8,
+                    gain_db: -80, // -8.0 dB in tenths
                 },
             ],
             locked: false,
@@ -550,8 +592,8 @@ mod tests {
         assert_eq!(decoded.name, "My Preset");
         assert_eq!(decoded.gain_db, 36);
         assert!(decoded.muted);
-        assert_eq!(decoded.eq_bands[0].gain_db, 4);
-        assert_eq!(decoded.eq_bands[4].gain_db, -8);
+        assert_eq!(decoded.eq_bands[0].gain_db, 40); // +4.0 dB in tenths
+        assert_eq!(decoded.eq_bands[4].gain_db, -80); // -8.0 dB in tenths
         assert!(decoded.denoiser_enabled);
         assert!(!decoded.popper_stopper_enabled);
         assert_eq!(decoded.tone, -5);
@@ -579,7 +621,7 @@ mod tests {
         assert_eq!(target.compressor, CompressorPreset::Medium);
         assert_eq!(target.hpf, HpfFrequency::Hz75);
         assert!(target.eq_enabled);
-        assert_eq!(target.eq_bands[0].gain_db, 4);
+        assert_eq!(target.eq_bands[0].gain_db, 40); // +4.0 dB in tenths
         assert!(target.denoiser_enabled);
         assert!(!target.popper_stopper_enabled);
         assert!(target.mute_btn_disabled);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,11 +1,12 @@
 //! Shure USB HID Protocol Implementation
 //!
-//! Covers two devices:
-//!   - Shure MVX2U  (VID 0x14ED, PID 0x1013) — XLR-to-USB interface
-//!   - Shure MV6    (VID 0x14ED, PID 0x1026) — USB gaming microphone
+//! Covers three devices:
+//!   - Shure MVX2U       (VID 0x14ED, PID 0x1013) — XLR-to-USB interface (Gen 1)
+//!   - Shure MVX2U Gen 2 (VID 0x14ED, PID 0x1033) — XLR-to-USB interface (Gen 2, new DSP)
+//!   - Shure MV6         (VID 0x14ED, PID 0x1026) — USB gaming microphone
 //!
-//! Both devices use the same packet framing, CRC algorithm, and command
-//! class structure. Feature addresses differ between models.
+//! All devices use the same packet framing, CRC algorithm, and command
+//! class structure. Feature addresses and encodings differ between models.
 //!
 //! Packet structure (64 bytes total, written via hidapi):
 //!
@@ -27,13 +28,14 @@
 //!
 //! USB IDs:
 //!   Vendor ID:  0x14ED  (Shure)
-//!   Product ID: 0x1013  (MVX2U)
+//!   Product ID: 0x1013  (MVX2U Gen 1)
+//!   Product ID: 0x1033  (MVX2U Gen 2)
 //!   Product ID: 0x1026  (MV6)
 //!
 //! Every SET command must be followed by a CONFIRM packet (CMD_CONFIRM).
 //! GET commands receive a response on the next `read()`.
 //!
-//! ── MVX2U Feature addresses (2 bytes) ────────────────────────────────────────
+//! ── MVX2U Gen 1 Feature addresses (2 bytes) ──────────────────────────────────
 //!   Config lock:    [0x00, 0xA6]  — 1 byte: 0=unlocked, 1=locked
 //!                                   Uses CMD_GET_LOCK / CMD_SET_LOCK (last byte 0x01, not 0x02)
 //!                                   Payload prefix byte is 0x06 (not 0x00 or 0x01)
@@ -51,10 +53,41 @@
 //!   Monitor mix:    [0x01, 0x86]  — 1 byte: 0=full mic, 100=full playback
 //!   EQ master:      [0x02, 0x00]  — 1 byte: 0=bypass, 1=enabled
 //!   EQ band enable: [0x02, 0xN0]  — 1 byte: 0=off, 1=on  (N = 1,2,3,4,5 per band)
-//!   EQ band gain:   [0x02, 0xN4]  — 16-bit signed big-endian, units: gain_db * 10
+//!   EQ band gain:   [0x02, 0xN4]  — Gen 1: 16-bit signed big-endian, units: gain_db * 10
+//!                                   Gen 2: 8-bit signed (i8), units: gain_db * 10
+//!                                   Same address; wire width distinguishes the model.
+//!                                   Confirmed by probe capture against Gen 2 firmware.
 //!
 //! EQ bands have fixed center frequencies: 100, 250, 1000, 4000, 10000 Hz.
 //! Frequency and Q are not adjustable on this device.
+//!
+//! ── MVX2U Gen 2 Feature addresses (2 bytes) ──────────────────────────────────
+//! Confirmed by probe sweep against Gen 2 firmware (PID 0x1033).
+//!
+//!   Gain (manual):  [0x01, 0x02]  — same as Gen 1 (16-bit BE, gain_db * 100, 0–60 dB)
+//!   Mute:           [0x01, 0x04]  — same as Gen 1
+//!   HPF:            [0x01, 0x06]  — same as Gen 1
+//!   Limiter:        [0x01, 0x51]  — same as Gen 1
+//!   Denoiser:       [0x01, 0x58]  — same as MV6: 0=off, 1=on (confirmed by probe)
+//!   Compressor:     [0x01, 0x5C]  — same as Gen 1
+//!   Phantom (48V):  [0x01, 0x66]  — same as Gen 1
+//!   Auto level:     [0x01, 0x85]  — same as Gen 1: 0=manual, 1=auto
+//!   Monitor mix:    [0x01, 0x86]  — same address; SET uses HDR_CONSTANT=0x00 (like MV6)
+//!   Gain lock:      [0x01, 0xF3]  — same as MV6 (confirmed by probe diff)
+//!   Tone slider:    [0x02, 0x04]  — same as MV6: 16-bit signed BE, units: percent
+//!                                   Range: -100 (Dark) to +100 (Bright), steps of 10.
+//!                                   Present in both Auto and Manual modes.
+//!   EQ band gain:   [0x02, 0xN4]  — 8-bit signed (i8), units: gain_db * 10
+//!                                   Gen 2 uses 1-byte encoding vs Gen 1's 2-byte i16.
+//!                                   Same addresses as Gen 1. Range: -8 to +6 dB, 0.5 dB steps.
+//!   EQ band freq:   [0x02, 0xN1]  — read-only 16-bit BE Hz value (100/250/1k/4k/10k)
+//!                                   Gen 2 exposes center frequencies as readable registers.
+//!                                   We do not read these; EQ_BAND_FREQS matches confirmed values.
+//!   Popper stopper: [0x03, 0x81]  — same as MV6 (confirmed by probe)
+//!
+//!   ABSENT on Gen 2 (vs Gen 1): config lock [0x00, 0xA6], EQ master [0x02, 0x00],
+//!   EQ band enable [0x02, 0xN0], auto position [0x01, 0x82], auto tone [0x01, 0x83],
+//!   auto gain [0x01, 0x87]. Gen 2 has no per-band enable and no master EQ toggle.
 //!
 //! ── MV6 Feature addresses (2 bytes) ──────────────────────────────────────────
 //! All confirmed by GET probe against firmware 1.3.0.6 unless noted.
@@ -95,8 +128,10 @@
 //!                                    0 = Natural (confirmed at factory default).
 
 pub const VID: u16 = 0x14ED;
-/// MVX2U: XLR-to-USB audio interface.
+/// MVX2U Gen 1: XLR-to-USB audio interface.
 pub const PID: u16 = 0x1013;
+/// MVX2U Gen 2: XLR-to-USB interface with new DSP (denoiser, popper stopper, tone, gain lock).
+pub const MVX2U_GEN2_PID: u16 = 0x1033;
 /// MV6: USB gaming microphone.
 pub const MV6_PID: u16 = 0x1026;
 
@@ -105,6 +140,7 @@ pub const MV6_PID: u16 = 0x1026;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum DeviceModel {
     Mvx2u,
+    Mvx2uGen2,
     Mv6,
 }
 
@@ -112,7 +148,7 @@ impl DeviceModel {
     /// Maximum manual gain in dB for this device.
     pub fn max_gain_db(&self) -> u8 {
         match self {
-            DeviceModel::Mvx2u => 60,
+            DeviceModel::Mvx2u | DeviceModel::Mvx2uGen2 => 60,
             DeviceModel::Mv6 => 36,
         }
     }
@@ -121,6 +157,7 @@ impl DeviceModel {
     pub fn display_name(&self) -> &'static str {
         match self {
             DeviceModel::Mvx2u => "Shure MVX2U",
+            DeviceModel::Mvx2uGen2 => "Shure MVX2U Gen 2",
             DeviceModel::Mv6 => "Shure MV6",
         }
     }
@@ -241,11 +278,12 @@ pub struct DeviceState {
     /// Compressor preset. MVX2U only.
     pub compressor: CompressorPreset,
     pub hpf: HpfFrequency,
-    /// 5-band parametric EQ master enable. MVX2U only.
+    /// 5-band parametric EQ master enable. MVX2U Gen 1 only. Gen 2 has no master toggle.
     pub eq_enabled: bool,
-    /// 5 EQ bands at fixed frequencies (100, 250, 1k, 4k, 10k Hz). MVX2U only.
+    /// 5 EQ bands at fixed frequencies (100, 250, 1k, 4k, 10k Hz). MVX2U Gen 1 and Gen 2.
+    /// `gain_db` is in tenths of dB. `enabled` is unused on Gen 2 (always active).
     pub eq_bands: [EqBand; 5],
-    /// Config lock (ignores SET commands while locked). MVX2U only.
+    /// Config lock (ignores SET commands while locked). MVX2U Gen 1 only.
     pub locked: bool,
 
     // ── MV6-specific fields ───────────────────────────────────────────────────
@@ -547,13 +585,19 @@ impl std::fmt::Display for HpfFrequency {
 /// One of the 5 parametric EQ bands.
 ///
 /// Center frequencies are fixed by hardware: 100, 250, 1000, 4000, 10000 Hz.
-/// Q is not adjustable. Only gain (−8 to +6 dB in steps of 2) and
-/// enabled/disabled are settable.
+/// Q is not adjustable.
+///
+/// `gain_db` is stored in **tenths of dB** (e.g. `−65` = −6.5 dB).
+///
+/// Gen 1 range: −8.0 to +6.0 dB in steps of 2.0 dB (step = 20 tenths).
+///   Wire format: 16-bit signed big-endian (value already in tenths, no multiply needed).
+/// Gen 2 range: −8.0 to +6.0 dB in steps of 0.5 dB (step = 5 tenths).
+///   Wire format: 8-bit signed i8 (value already in tenths, no multiply needed).
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct EqBand {
-    /// Gain in dB, range −8 to +6 in steps of 2.
-    pub gain_db: i8,
-    /// Whether this band is active.
+    /// Gain in tenths of dB. Gen 1 range: −80..+60 (steps of 20). Gen 2: −80..+60 (steps of 5).
+    pub gain_db: i16,
+    /// Whether this band is active. Gen 2 devices have no per-band enable; always true.
     pub enabled: bool,
 }
 
@@ -883,17 +927,30 @@ pub fn cmd_set_eq_band_enable(seq: u8, band: usize, enabled: bool) -> Vec<u8> {
     cmd_set(seq, &EQ_BAND_ADDRS[band].0, &[u8::from(enabled)])
 }
 
-/// Set EQ band gain. `gain_db` is clamped to −8..+6 and rounded to the
-/// nearest even value (hardware supports −8, −6, −4, −2, 0, 2, 4, 6 only).
-/// Encoded as `gain_db * 10` in 16-bit signed big-endian.
-pub fn cmd_set_eq_band_gain(seq: u8, band: usize, gain_db: i8) -> Vec<u8> {
+/// Set EQ band gain. `gain_db` is in tenths of dB, clamped to −80..+60.
+///
+/// Wire encoding is model-specific:
+///   - Gen 1 (Mvx2u):      16-bit signed big-endian (value in tenths, no multiply)
+///   - Gen 2 (Mvx2uGen2):  8-bit signed i8 (value in tenths, no multiply)
+///
+/// Gen 1 callers should pass multiples of 20 (2.0 dB steps).
+/// Gen 2 callers should pass multiples of 5 (0.5 dB steps).
+pub fn cmd_set_eq_band_gain(seq: u8, band: usize, gain_tenths: i16, model: DeviceModel) -> Vec<u8> {
     assert!(
         band < EQ_BAND_ADDRS.len(),
         "band index out of range: {band}"
     );
-    let clamped = gain_db.clamp(-8, 6);
-    let raw = (clamped as i16 * 10).to_be_bytes();
-    cmd_set(seq, &EQ_BAND_ADDRS[band].1, &raw)
+    let clamped = gain_tenths.clamp(-80, 60);
+    match model {
+        DeviceModel::Mvx2uGen2 => {
+            // Gen 2: 1-byte signed encoding confirmed by probe capture.
+            cmd_set(seq, &EQ_BAND_ADDRS[band].1, &[clamped as i8 as u8])
+        }
+        _ => {
+            // Gen 1: 2-byte signed big-endian encoding.
+            cmd_set(seq, &EQ_BAND_ADDRS[band].1, &clamped.to_be_bytes())
+        }
+    }
 }
 
 // ── MV6 SET constructors ──────────────────────────────────────────────────────
@@ -1160,11 +1217,17 @@ pub fn apply_response(feat_addr: [u8; 2], value: &[u8], state: &mut DeviceState)
                     return true;
                 }
                 if feat_addr == *gain_addr {
-                    if value.len() < 2 {
+                    // Gen 1 returns 2-byte i16 (value in tenths of dB).
+                    // Gen 2 returns 1-byte i8 (value in tenths of dB).
+                    // The length of the response determines which encoding was used.
+                    let gain_tenths: i16 = if value.len() >= 2 {
+                        i16::from_be_bytes([value[0], value[1]])
+                    } else if value.len() == 1 {
+                        value[0] as i8 as i16
+                    } else {
                         return false;
-                    }
-                    let raw = i16::from_be_bytes([value[0], value[1]]);
-                    state.eq_bands[i].gain_db = (raw / 10).clamp(-8, 6) as i8;
+                    };
+                    state.eq_bands[i].gain_db = gain_tenths.clamp(-80, 60);
                     return true;
                 }
             }
@@ -1467,27 +1530,54 @@ mod tests {
     }
 
     #[test]
-    fn eq_band_gain_encoding() {
-        // +3 dB → 30 → 0x001E
-        let pkt = cmd_set_eq_band_gain(0, 0, 3);
+    fn eq_band_gain_encoding_gen1() {
+        // Gen 1: 16-bit signed BE. +3.0 dB = 30 tenths → 0x001E
+        let pkt = cmd_set_eq_band_gain(0, 0, 30, DeviceModel::Mvx2u);
         let raw = i16::from_be_bytes([pkt[16], pkt[17]]);
-        assert_eq!(raw, 30, "+3 dB must encode as 30");
+        assert_eq!(raw, 30, "+3.0 dB (30 tenths) must encode as 30 in i16 BE");
 
-        // -6 dB → -60 → 0xFFC4
-        let pkt = cmd_set_eq_band_gain(0, 1, -6);
+        // -6.0 dB = -60 tenths → 0xFFC4
+        let pkt = cmd_set_eq_band_gain(0, 1, -60, DeviceModel::Mvx2u);
         let raw = i16::from_be_bytes([pkt[16], pkt[17]]);
-        assert_eq!(raw, -60, "-6 dB must encode as -60");
+        assert_eq!(
+            raw, -60,
+            "-6.0 dB (-60 tenths) must encode as -60 in i16 BE"
+        );
+    }
+
+    #[test]
+    fn eq_band_gain_encoding_gen2() {
+        // Gen 2: 1-byte signed. -6.5 dB = -65 tenths → 0xBF (confirmed by probe)
+        let pkt = cmd_set_eq_band_gain(0, 0, -65, DeviceModel::Mvx2uGen2);
+        assert_eq!(pkt[16], 0xBF, "-6.5 dB (-65 tenths) must encode as 0xBF");
+        assert_eq!(pkt.len(), PACKET_SIZE, "packet must be 64 bytes");
+
+        // +4.0 dB = +40 tenths → 0x28 (confirmed by probe)
+        let pkt = cmd_set_eq_band_gain(0, 4, 40, DeviceModel::Mvx2uGen2);
+        assert_eq!(pkt[16], 0x28, "+4.0 dB (+40 tenths) must encode as 0x28");
     }
 
     #[test]
     fn eq_band_gain_clamps() {
-        let pkt_hi = cmd_set_eq_band_gain(0, 0, 127);
+        // Gen 1: clamp to +60 tenths (+6.0 dB) and -80 tenths (-8.0 dB)
+        let pkt_hi = cmd_set_eq_band_gain(0, 0, 1000, DeviceModel::Mvx2u);
         let raw_hi = i16::from_be_bytes([pkt_hi[16], pkt_hi[17]]);
-        assert_eq!(raw_hi, 60, "+127 dB must clamp to +6 dB (raw 60)");
+        assert_eq!(raw_hi, 60, "1000 tenths must clamp to +60 (Gen 1)");
 
-        let pkt_lo = cmd_set_eq_band_gain(0, 0, -128);
+        let pkt_lo = cmd_set_eq_band_gain(0, 0, -1000, DeviceModel::Mvx2u);
         let raw_lo = i16::from_be_bytes([pkt_lo[16], pkt_lo[17]]);
-        assert_eq!(raw_lo, -80, "-128 dB must clamp to -8 dB (raw -80)");
+        assert_eq!(raw_lo, -80, "-1000 tenths must clamp to -80 (Gen 1)");
+
+        // Gen 2: same clamp, 1-byte encoding
+        let pkt_hi2 = cmd_set_eq_band_gain(0, 0, 1000, DeviceModel::Mvx2uGen2);
+        assert_eq!(pkt_hi2[16], 60u8, "1000 tenths must clamp to 60 (Gen 2)");
+
+        let pkt_lo2 = cmd_set_eq_band_gain(0, 0, -1000, DeviceModel::Mvx2uGen2);
+        assert_eq!(
+            pkt_lo2[16],
+            (-80i8) as u8,
+            "-1000 tenths must clamp to -80 (Gen 2)"
+        );
     }
 
     #[test]
@@ -1495,14 +1585,18 @@ mod tests {
         // Band 0 (100 Hz): enable=0x0210, gain=0x0214
         let en_pkt = cmd_set_eq_band_enable(0, 0, true);
         assert_eq!(&en_pkt[14..16], &[0x02u8, 0x10]);
-        let gain_pkt = cmd_set_eq_band_gain(0, 0, 0);
+        let gain_pkt = cmd_set_eq_band_gain(0, 0, 0, DeviceModel::Mvx2u);
         assert_eq!(&gain_pkt[14..16], &[0x02u8, 0x14]);
 
         // Band 4 (10kHz): enable=0x0250, gain=0x0254
         let en_pkt4 = cmd_set_eq_band_enable(0, 4, false);
         assert_eq!(&en_pkt4[14..16], &[0x02u8, 0x50]);
-        let gain_pkt4 = cmd_set_eq_band_gain(0, 4, 0);
+        let gain_pkt4 = cmd_set_eq_band_gain(0, 4, 0, DeviceModel::Mvx2u);
         assert_eq!(&gain_pkt4[14..16], &[0x02u8, 0x54]);
+
+        // Gen 2 uses the same gain addresses
+        let gain_pkt_g2 = cmd_set_eq_band_gain(0, 0, 0, DeviceModel::Mvx2uGen2);
+        assert_eq!(&gain_pkt_g2[14..16], &[0x02u8, 0x14]);
     }
 
     #[test]
@@ -1740,12 +1834,12 @@ mod tests {
         // Table: (band_index, gain_addr, raw_hi, raw_lo, expected_gain_db)
         // gain_addr = EQ_BAND_ADDRS[i].1; raw = gain_db * 10 as i16 big-endian.
         // Bands: 0=100Hz(0x14), 1=250Hz(0x24), 2=1kHz(0x34), 3=4kHz(0x44), 4=10kHz(0x54)
-        let cases: &[(usize, [u8; 2], u8, u8, i8)] = &[
-            (0, [0x02, 0x14], 0x00, 0x28, 4),  // +4 dB = raw 40
-            (1, [0x02, 0x24], 0xFF, 0xC4, -6), // -6 dB = raw -60
-            (2, [0x02, 0x34], 0x00, 0x1E, 3),  // +3 dB = raw 30
-            (3, [0x02, 0x44], 0xFF, 0xD8, -4), // -4 dB = raw -40
-            (4, [0x02, 0x54], 0x00, 0x3C, 6),  // +6 dB = raw 60
+        let cases: &[(usize, [u8; 2], u8, u8, i16)] = &[
+            (0, [0x02, 0x14], 0x00, 0x28, 40),  // +4.0 dB = 40 tenths
+            (1, [0x02, 0x24], 0xFF, 0xC4, -60), // -6.0 dB = -60 tenths
+            (2, [0x02, 0x34], 0x00, 0x1E, 30),  // +3.0 dB = 30 tenths
+            (3, [0x02, 0x44], 0xFF, 0xD8, -40), // -4.0 dB = -40 tenths
+            (4, [0x02, 0x54], 0x00, 0x3C, 60),  // +6.0 dB = 60 tenths
         ];
         for &(band, addr, hi, lo, expected_db) in cases {
             let mut state = DeviceState::default();
@@ -2298,6 +2392,7 @@ mod tests {
     #[test]
     fn device_model_max_gain_db() {
         assert_eq!(DeviceModel::Mvx2u.max_gain_db(), 60);
+        assert_eq!(DeviceModel::Mvx2uGen2.max_gain_db(), 60);
         assert_eq!(DeviceModel::Mv6.max_gain_db(), 36);
     }
 
@@ -2352,5 +2447,48 @@ mod tests {
     fn mv6_gain_lock_apply_response_empty_returns_false() {
         let mut state = DeviceState::default();
         assert!(!apply_response(MV6_FEAT_GAIN_LOCK, &[], &mut state));
+    }
+
+    // ── Gen 2 EQ band gain apply_response ─────────────────────────────────────
+
+    #[test]
+    fn eq_band_gain_apply_response_gen1_two_bytes() {
+        // Gen 1: 2-byte i16 response → stored directly as tenths
+        let cases: &[(&[u8], i16)] = &[
+            (&[0x00, 0x1E], 30),  // +3.0 dB
+            (&[0xFF, 0xC4], -60), // -6.0 dB
+            (&[0x00, 0x00], 0),   // 0 dB
+            (&[0x00, 0x3C], 60),  // +6.0 dB (max)
+            (&[0xFF, 0xB0], -80), // -8.0 dB (min)
+        ];
+        for (bytes, expected) in cases {
+            let mut state = DeviceState::default();
+            assert!(apply_response([0x02, 0x14], bytes, &mut state));
+            assert_eq!(state.eq_bands[0].gain_db, *expected);
+        }
+    }
+
+    #[test]
+    fn eq_band_gain_apply_response_gen2_one_byte() {
+        // Gen 2: 1-byte i8 response — values confirmed by probe capture
+        let cases: &[(&[u8], i16)] = &[
+            (&[0xBF], -65), // -6.5 dB (probe confirmed)
+            (&[0xE7], -25), // -2.5 dB (probe confirmed)
+            (&[0x14], 20),  // +2.0 dB (probe confirmed)
+            (&[0xE2], -30), // -3.0 dB (probe confirmed)
+            (&[0x28], 40),  // +4.0 dB (probe confirmed)
+            (&[0x00], 0),   // 0 dB
+        ];
+        for (bytes, expected) in cases {
+            let mut state = DeviceState::default();
+            assert!(apply_response([0x02, 0x14], bytes, &mut state));
+            assert_eq!(state.eq_bands[0].gain_db, *expected);
+        }
+    }
+
+    #[test]
+    fn eq_band_gain_apply_response_empty_returns_false() {
+        let mut state = DeviceState::default();
+        assert!(!apply_response([0x02, 0x14], &[], &mut state));
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -269,13 +269,13 @@ pub struct DeviceState {
     /// Gain preset for Auto Level mode. MVX2U only.
     pub auto_gain: AutoGain,
     pub muted: bool,
-    /// 48V phantom power. MVX2U only (XLR input).
+    /// 48V phantom power. MVX2U Gen 1 and Gen 2 only (XLR input).
     pub phantom_power: bool,
-    /// Monitor mix: 0 = 100% mic, 100 = 100% playback. MVX2U only.
+    /// Monitor mix: 0 = 100% mic, 100 = 100% playback. MVX2U Gen 1, Gen 2, and MV6.
     pub monitor_mix: u8,
-    /// Limiter. MVX2U only.
+    /// Limiter. MVX2U Gen 1 and Gen 2 only.
     pub limiter_enabled: bool,
-    /// Compressor preset. MVX2U only.
+    /// Compressor preset. MVX2U Gen 1 and Gen 2 only.
     pub compressor: CompressorPreset,
     pub hpf: HpfFrequency,
     /// 5-band parametric EQ master enable. MVX2U Gen 1 only. Gen 2 has no master toggle.
@@ -286,18 +286,18 @@ pub struct DeviceState {
     /// Config lock (ignores SET commands while locked). MVX2U Gen 1 only.
     pub locked: bool,
 
-    // ── MV6-specific fields ───────────────────────────────────────────────────
-    /// Real-time denoiser. MV6 only.
+    // ── MV6 and MVX2U Gen 2 fields ───────────────────────────────────────────
+    /// Real-time denoiser. MV6 and MVX2U Gen 2.
     pub denoiser_enabled: bool,
-    /// Popper stopper. MV6 only. Address [0x03, 0x81] confirmed by MOTIV app probe diff.
+    /// Popper stopper. MV6 and MVX2U Gen 2. Address [0x03, 0x81] confirmed by MOTIV app probe diff.
     pub popper_stopper_enabled: bool,
     /// Mute button disable. MV6 only. Address [0x0C, 0x00] confirmed by Wireshark capture.
     /// GET uses CMD_GET_LOCK with inverted encoding; read from device at startup.
     pub mute_btn_disabled: bool,
-    /// Tone character. MV6 only. Range: -10 to +10 (displayed as × 10%).
+    /// Tone character. MV6 and MVX2U Gen 2. Range: -10 to +10 (displayed as × 10%).
     /// -10 = 100% Dark, 0 = Natural, +10 = 100% Bright.
     pub tone: i8,
-    /// Gain lock (Manual mode only). MV6 only. Prevents gain from being changed
+    /// Gain lock (Manual mode only). MV6 and MVX2U Gen 2. Prevents gain from being changed
     /// while locked. Address [0x01, 0xF3] confirmed by probe diff.
     pub mv6_gain_locked: bool,
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -166,6 +166,17 @@ fn draw_status(f: &mut Frame, app: &App, area: Rect) {
             " Editing name — type to change  [Enter/Esc] confirm  [Backspace] delete",
             Style::default().fg(C_ACCENT),
         )
+    } else if app.active_tab == Tab::Eq
+        && matches!(
+            app.device_model,
+            crate::protocol::DeviceModel::Mvx2u | crate::protocol::DeviceModel::Mvx2uGen2
+        )
+        && app.device_state.mode == crate::protocol::InputMode::Manual
+    {
+        Span::styled(
+            " [Tab] Next section  [↑↓] Focus  [←→] Adjust  [f] Flat  [r] Refresh  [?] Help  [q] Quit",
+            Style::default().fg(C_DISABLED),
+        )
     } else {
         Span::styled(
             " [Tab] Next section  [↑↓] Focus  [←→/Enter] Adjust  [r] Refresh  [?] Help  [q] Quit",
@@ -202,6 +213,8 @@ fn draw_main_left(f: &mut Frame, app: &App, area: Rect) {
     match (app.device_model, app.device_state.mode) {
         (DeviceModel::Mv6, InputMode::Manual) => draw_main_left_mv6_manual(f, app, area),
         (DeviceModel::Mv6, InputMode::Auto) => draw_main_left_mv6_auto(f, app, area),
+        (DeviceModel::Mvx2uGen2, InputMode::Manual) => draw_main_left_gen2_manual(f, app, area),
+        (DeviceModel::Mvx2uGen2, InputMode::Auto) => draw_main_left_gen2_auto(f, app, area),
         (DeviceModel::Mvx2u, InputMode::Auto) => draw_main_left_auto(f, app, area),
         (DeviceModel::Mvx2u, InputMode::Manual) => draw_main_left_manual(f, app, area),
     }
@@ -272,50 +285,7 @@ fn draw_main_left_mv6_manual(f: &mut Frame, app: &App, area: Rect) {
         .label(format!("{gain} / {} dB", app.device_model.max_gain_db()));
     f.render_widget(gauge, rows[2]);
 
-    // ── Gain Lock ─────────────────────────────────────────────────────────────
-    let lock_focused = app.focus == Focus::GainLock;
-    let lock_icon = if gain_locked { "🔒" } else { "🔓" };
-    let gain_lock_p = Paragraph::new(Line::from(vec![
-        Span::styled(
-            format!("{lock_icon}  Gain Lock:  "),
-            Style::default().fg(C_DIM),
-        ),
-        if gain_locked {
-            Span::styled(
-                "LOCKED",
-                Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD),
-            )
-        } else {
-            Span::styled("Unlocked", Style::default().fg(C_SUCCESS))
-        },
-        Span::styled(
-            if lock_focused { "  [Enter] toggle" } else { "" },
-            Style::default().fg(C_DIM),
-        ),
-    ]))
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(if lock_focused {
-                Style::default().fg(C_FOCUS)
-            } else if gain_locked {
-                Style::default().fg(C_ERROR)
-            } else {
-                Style::default().fg(C_BORDER)
-            })
-            .title(Span::styled(
-                "  Gain Lock  ",
-                if lock_focused {
-                    Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
-                } else if gain_locked {
-                    Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default().fg(C_TEXT)
-                },
-            )),
-    );
-    f.render_widget(gain_lock_p, rows[3]);
+    draw_gain_lock_block(f, app, rows[3]);
 
     draw_meter(f, app, rows[4]);
     draw_monitor_mix_gauge(f, app, rows[5]);
@@ -338,6 +308,101 @@ fn draw_main_left_mv6_auto(f: &mut Frame, app: &App, area: Rect) {
     draw_mute_block(f, app, rows[1]);
     draw_meter(f, app, rows[2]);
     draw_monitor_mix_gauge(f, app, rows[3]);
+}
+
+// Gen 2 Manual: Mode → Mute → Gain → GainLock → Meter → MonitorMix → Phantom
+fn draw_main_left_gen2_manual(f: &mut Frame, app: &App, area: Rect) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // mode
+            Constraint::Length(3), // mute
+            Constraint::Length(3), // gain gauge
+            Constraint::Length(3), // gain lock
+            Constraint::Length(4), // level meter
+            Constraint::Length(3), // monitor mix
+            Constraint::Length(3), // phantom
+            Constraint::Min(0),    // spacer
+        ])
+        .margin(1)
+        .split(area);
+
+    draw_mode_block(f, app, rows[0]);
+    draw_mute_block(f, app, rows[1]);
+
+    let gain_focused = app.focus == Focus::Gain;
+    let gain = app.device_state.gain_db;
+    let gain_locked = app.device_state.mv6_gain_locked;
+    let gauge = Gauge::default()
+        .block(
+            Block::default()
+                .title(Line::from(vec![
+                    Span::styled("  GAIN  ", focused_style(gain_focused)),
+                    Span::styled(
+                        format!(" {} dB ", gain),
+                        Style::default()
+                            .fg(if gain_locked { C_DIM } else { C_ACCENT })
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(
+                        if gain_focused && !gain_locked {
+                            "  ◄ ► or ←→ to adjust"
+                        } else if gain_focused && gain_locked {
+                            "  🔒 locked"
+                        } else {
+                            ""
+                        },
+                        Style::default().fg(C_DIM),
+                    ),
+                ]))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(if gain_focused {
+                    Style::default().fg(C_FOCUS)
+                } else {
+                    Style::default().fg(C_BORDER)
+                }),
+        )
+        .gauge_style(
+            Style::default()
+                .fg(if gain_locked { C_DISABLED } else { C_ACCENT })
+                .bg(C_SURFACE)
+                .add_modifier(if gain_focused {
+                    Modifier::BOLD
+                } else {
+                    Modifier::empty()
+                }),
+        )
+        .ratio(gain as f64 / app.device_model.max_gain_db() as f64)
+        .label(format!("{gain} / {} dB", app.device_model.max_gain_db()));
+    f.render_widget(gauge, rows[2]);
+
+    draw_gain_lock_block(f, app, rows[3]);
+    draw_meter(f, app, rows[4]);
+    draw_monitor_mix_gauge(f, app, rows[5]);
+    draw_phantom_block(f, app, rows[6]);
+}
+
+// Gen 2 Auto: Mode → Mute → Meter → MonitorMix → Phantom
+fn draw_main_left_gen2_auto(f: &mut Frame, app: &App, area: Rect) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // mode
+            Constraint::Length(3), // mute
+            Constraint::Length(4), // level meter
+            Constraint::Length(3), // monitor mix
+            Constraint::Length(3), // phantom
+            Constraint::Min(0),    // spacer
+        ])
+        .margin(1)
+        .split(area);
+
+    draw_mode_block(f, app, rows[0]);
+    draw_mute_block(f, app, rows[1]);
+    draw_meter(f, app, rows[2]);
+    draw_monitor_mix_gauge(f, app, rows[3]);
+    draw_phantom_block(f, app, rows[4]);
 }
 
 fn draw_main_left_manual(f: &mut Frame, app: &App, area: Rect) {
@@ -653,28 +718,9 @@ fn draw_monitor_mix_gauge(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(mix_gauge, area);
 }
 
-/// Renders the controls shared by both Manual and Auto layouts that follow
-/// the mode-specific top section: Level Meter, Monitor Mix, Phantom Power,
-/// Config Lock.
-///
-/// Control order follows the signal chain: observe the level produced by the
-/// gain you just set, adjust monitoring, then the rarely-changed setup
-/// controls (phantom, lock) at the bottom.
-///
-/// `rows` must have at least 4 elements (indices 0–3).
-fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
-    assert!(
-        rows.len() >= 4,
-        "draw_main_shared requires at least 4 row slots, got {}",
-        rows.len()
-    );
-    // ── Level Meter ───────────────────────────────────────────────────────────
-    draw_meter(f, app, rows[0]);
-
-    // ── Monitor Mix ───────────────────────────────────────────────────────────
-    draw_monitor_mix_gauge(f, app, rows[1]);
-
-    // ── Phantom Power ─────────────────────────────────────────────────────────
+/// Renders the Phantom Power block as a standalone control.
+/// Used by Gen 2 main tab and MVX2U via draw_main_shared.
+fn draw_phantom_block(f: &mut Frame, app: &App, area: Rect) {
     let ph_focused = app.focus == Focus::Phantom;
     let phantom_p = Paragraph::new(Line::from(vec![
         Span::styled("48V Phantom Power:  ", Style::default().fg(C_DIM)),
@@ -706,7 +752,80 @@ fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
                 },
             )),
     );
-    f.render_widget(phantom_p, rows[2]);
+    f.render_widget(phantom_p, area);
+}
+
+/// Renders the Gain Lock block. Used by MV6 and Gen 2.
+fn draw_gain_lock_block(f: &mut Frame, app: &App, area: Rect) {
+    let lock_focused = app.focus == Focus::GainLock;
+    let gain_locked = app.device_state.mv6_gain_locked;
+    let lock_icon = if gain_locked { "🔒" } else { "🔓" };
+    let gain_lock_p = Paragraph::new(Line::from(vec![
+        Span::styled(
+            format!("{lock_icon}  Gain Lock:  "),
+            Style::default().fg(C_DIM),
+        ),
+        if gain_locked {
+            Span::styled(
+                "LOCKED",
+                Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD),
+            )
+        } else {
+            Span::styled("Unlocked", Style::default().fg(C_SUCCESS))
+        },
+        Span::styled(
+            if lock_focused { "  [Enter] toggle" } else { "" },
+            Style::default().fg(C_DIM),
+        ),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if lock_focused {
+                Style::default().fg(C_FOCUS)
+            } else if gain_locked {
+                Style::default().fg(C_ERROR)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .title(Span::styled(
+                "  Gain Lock  ",
+                if lock_focused {
+                    Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+                } else if gain_locked {
+                    Style::default().fg(C_ERROR).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(C_TEXT)
+                },
+            )),
+    );
+    f.render_widget(gain_lock_p, area);
+}
+
+/// Renders the controls shared by both Manual and Auto layouts that follow
+/// the mode-specific top section: Level Meter, Monitor Mix, Phantom Power,
+/// Config Lock.
+///
+/// Control order follows the signal chain: observe the level produced by the
+/// gain you just set, adjust monitoring, then the rarely-changed setup
+/// controls (phantom, lock) at the bottom.
+///
+/// `rows` must have at least 4 elements (indices 0–3).
+fn draw_main_shared(f: &mut Frame, app: &App, rows: &[Rect]) {
+    assert!(
+        rows.len() >= 4,
+        "draw_main_shared requires at least 4 row slots, got {}",
+        rows.len()
+    );
+    // ── Level Meter ───────────────────────────────────────────────────────────
+    draw_meter(f, app, rows[0]);
+
+    // ── Monitor Mix ───────────────────────────────────────────────────────────
+    draw_monitor_mix_gauge(f, app, rows[1]);
+
+    // ── Phantom Power ─────────────────────────────────────────────────────────
+    draw_phantom_block(f, app, rows[2]);
 
     // ── Config Lock ───────────────────────────────────────────────────────────
     let lock_focused = app.focus == Focus::Lock;
@@ -877,11 +996,23 @@ fn draw_main_right(f: &mut Frame, app: &App, area: Rect) {
                     Span::styled("Mode        : ", Style::default().fg(C_DIM)),
                     Span::styled(ds.mode.to_string(), Style::default().fg(C_ACCENT)),
                 ]),
+                Line::from(vec![
+                    Span::styled("Tone        : ", Style::default().fg(C_DIM)),
+                    Span::styled(tone_str, Style::default().fg(C_TEXT)),
+                ]),
             ];
             if ds.mode == InputMode::Manual {
                 l.push(Line::from(vec![
                     Span::styled("Gain        : ", Style::default().fg(C_DIM)),
                     Span::styled(format!("{} dB", ds.gain_db), Style::default().fg(C_TEXT)),
+                ]));
+                l.push(Line::from(vec![
+                    Span::styled("Gain Lock   : ", Style::default().fg(C_DIM)),
+                    if ds.mv6_gain_locked {
+                        Span::styled("LOCKED", Style::default().fg(C_ERROR))
+                    } else {
+                        Span::styled("Unlocked", Style::default().fg(C_SUCCESS))
+                    },
                 ]));
             }
             l.extend([
@@ -919,12 +1050,95 @@ fn draw_main_right(f: &mut Frame, app: &App, area: Rect) {
                     },
                 ]),
                 Line::from(vec![
+                    Span::styled("HPF         : ", Style::default().fg(C_DIM)),
+                    Span::styled(ds.hpf.to_string(), Style::default().fg(C_TEXT)),
+                ]),
+            ]);
+            l
+        }
+        DeviceModel::Mvx2uGen2 => {
+            let mut l = vec![
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("Mode        : ", Style::default().fg(C_DIM)),
+                    Span::styled(ds.mode.to_string(), Style::default().fg(C_ACCENT)),
+                ]),
+            ];
+            if ds.mode == InputMode::Manual {
+                l.push(Line::from(vec![
+                    Span::styled("Gain        : ", Style::default().fg(C_DIM)),
+                    Span::styled(format!("{} dB", ds.gain_db), Style::default().fg(C_TEXT)),
+                ]));
+                l.push(Line::from(vec![
+                    Span::styled("Gain Lock   : ", Style::default().fg(C_DIM)),
+                    if ds.mv6_gain_locked {
+                        Span::styled("LOCKED", Style::default().fg(C_ERROR))
+                    } else {
+                        Span::styled("Unlocked", Style::default().fg(C_SUCCESS))
+                    },
+                ]));
+            } else {
+                // Auto mode: show tone slider value
+                let pct = ds.tone as i32 * 10;
+                let tone_str = if pct < 0 {
+                    format!("{}% Dark", pct.abs())
+                } else if pct > 0 {
+                    format!("{}% Bright", pct)
+                } else {
+                    "Natural".to_string()
+                };
+                l.push(Line::from(vec![
                     Span::styled("Tone        : ", Style::default().fg(C_DIM)),
                     Span::styled(tone_str, Style::default().fg(C_TEXT)),
+                ]));
+            }
+            l.extend([
+                Line::from(vec![
+                    Span::styled("Muted       : ", Style::default().fg(C_DIM)),
+                    if ds.muted {
+                        Span::styled("YES", Style::default().fg(C_ERROR))
+                    } else {
+                        Span::styled("NO", Style::default().fg(C_SUCCESS))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Phantom     : ", Style::default().fg(C_DIM)),
+                    if ds.phantom_power {
+                        Span::styled("48V ON", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("OFF", Style::default().fg(C_DIM))
+                    },
+                ]),
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("Denoiser    : ", Style::default().fg(C_DIM)),
+                    if ds.denoiser_enabled {
+                        Span::styled("ON", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("OFF", Style::default().fg(C_DIM))
+                    },
+                ]),
+                Line::from(vec![
+                    Span::styled("Pop. Stopper: ", Style::default().fg(C_DIM)),
+                    if ds.popper_stopper_enabled {
+                        Span::styled("ON", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("OFF", Style::default().fg(C_DIM))
+                    },
                 ]),
                 Line::from(vec![
                     Span::styled("HPF         : ", Style::default().fg(C_DIM)),
                     Span::styled(ds.hpf.to_string(), Style::default().fg(C_TEXT)),
+                ]),
+                Line::from(vec![
+                    Span::styled("Limiter     : ", Style::default().fg(C_DIM)),
+                    if ds.mode == InputMode::Auto {
+                        Span::styled("auto", Style::default().fg(C_DISABLED))
+                    } else if ds.limiter_enabled {
+                        Span::styled("ON", Style::default().fg(C_SUCCESS))
+                    } else {
+                        Span::styled("OFF", Style::default().fg(C_DIM))
+                    },
                 ]),
             ]);
             l
@@ -1359,6 +1573,432 @@ fn draw_mv6_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// MVX2U Gen 2 EQ Tab — same visual style as Gen 1, no master enable, no per-band enable
+// ─────────────────────────────────────────────────────────────────────────────
+fn draw_gen2_eq_tab(f: &mut Frame, app: &App, area: Rect) {
+    // Gen 2: Auto mode shows the Tone slider; Manual mode shows the 5-band EQ.
+    if app.device_state.mode == InputMode::Auto {
+        draw_mv6_eq_tab(f, app, area);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // band selector header
+            Constraint::Min(0),    // band columns
+        ])
+        .margin(1)
+        .split(area);
+
+    // ── Header: band selector only (no master enable) ─────────────────────────
+    let selected_freq = EQ_BAND_FREQS[app.eq_selected_band];
+    let freq_label = if selected_freq >= 1000 {
+        format!("{}k Hz", selected_freq / 1000)
+    } else {
+        format!("{} Hz", selected_freq)
+    };
+    let band_sel_focused = app.focus == Focus::EqBandSelect;
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "Selected Band:  ",
+            Style::default().fg(if band_sel_focused { C_FOCUS } else { C_DIM }),
+        ),
+        Span::styled(
+            format!("Band {} ", app.eq_selected_band + 1),
+            if band_sel_focused {
+                Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
+            },
+        ),
+        Span::styled(format!("({})", freq_label), Style::default().fg(C_DIM)),
+        Span::styled(
+            if band_sel_focused {
+                "  ◄ ► to change band"
+            } else {
+                ""
+            },
+            Style::default().fg(C_DIM),
+        ),
+    ]))
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if band_sel_focused {
+                Style::default().fg(C_FOCUS)
+            } else {
+                Style::default().fg(C_BORDER)
+            }),
+    );
+    f.render_widget(header, chunks[0]);
+
+    // ── Band columns ──────────────────────────────────────────────────────────
+    let band_cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(vec![Constraint::Percentage(20); 5])
+        .split(chunks[1]);
+
+    for (i, band) in app.device_state.eq_bands.iter().enumerate() {
+        let selected = i == app.eq_selected_band;
+        let gain_foc = app.focus == Focus::EqGain(i);
+
+        let border_color = if gain_foc {
+            C_FOCUS
+        } else if selected {
+            C_ACCENT
+        } else {
+            C_BORDER
+        };
+
+        // Vertical gain bar: −8.0 dB = bottom, +6.0 dB = top. Total span = 14.0 dB.
+        // gain_db is in tenths, so range is −80..+60. bar_pos = (gain_db + 80) * 7 / 140.
+        let bar_height: i32 = 7;
+        let bar_pos = ((band.gain_db as i32 + 80) * bar_height / 140)
+            .max(0)
+            .min(bar_height);
+
+        let mut bar_lines: Vec<Line> = Vec::new();
+        for row in (0..=bar_height).rev() {
+            let ch = if row == bar_pos {
+                Span::styled(
+                    "━━━━",
+                    Style::default().fg(if band.gain_db > 0 {
+                        C_ACCENT
+                    } else {
+                        Color::Rgb(50, 150, 220)
+                    }),
+                )
+            } else if row == bar_height / 2 {
+                Span::styled("────", Style::default().fg(C_BORDER))
+            } else {
+                Span::styled("    ", Style::default())
+            };
+            bar_lines.push(Line::from(ch));
+        }
+
+        let freq = EQ_BAND_FREQS[i];
+        let freq_str = if freq >= 1000 {
+            format!("{}k Hz", freq / 1000)
+        } else {
+            format!("{} Hz", freq)
+        };
+
+        let gain_db_f = band.gain_db as f32 / 10.0;
+        let detail_lines = vec![
+            Line::from(vec![
+                Span::styled("Freq: ", Style::default().fg(C_DIM)),
+                Span::styled(freq_str, Style::default().fg(C_DIM)),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    "Gain: ",
+                    Style::default().fg(if gain_foc { C_FOCUS } else { C_DIM }),
+                ),
+                Span::styled(
+                    format!("{:+.1} dB", gain_db_f),
+                    if gain_foc {
+                        Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+                    } else if band.gain_db > 0 {
+                        Style::default().fg(C_ACCENT)
+                    } else if band.gain_db < 0 {
+                        Style::default().fg(Color::Rgb(50, 150, 220))
+                    } else {
+                        Style::default().fg(C_DIM)
+                    },
+                ),
+            ]),
+        ];
+
+        let mut all_lines = bar_lines;
+        all_lines.push(Line::from(""));
+        all_lines.extend(detail_lines);
+
+        let block = Paragraph::new(all_lines)
+            .block(
+                Block::default()
+                    .title(Span::styled(
+                        format!(" Band {} ", i + 1),
+                        if selected {
+                            Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(C_DIM)
+                        },
+                    ))
+                    .borders(Borders::ALL)
+                    .border_type(if selected {
+                        BorderType::Thick
+                    } else {
+                        BorderType::Rounded
+                    })
+                    .border_style(Style::default().fg(border_color))
+                    .padding(Padding::horizontal(1)),
+            )
+            .style(Style::default().bg(C_BG));
+        f.render_widget(block, band_cols[i]);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MVX2U Gen 2 Dynamics Tab — Limiter + Compressor (Gen 1 style) + Denoiser + Popper Stopper + HPF
+// ─────────────────────────────────────────────────────────────────────────────
+fn draw_gen2_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
+    let ds = &app.device_state;
+
+    // Auto mode: only Denoiser, Popper Stopper, HPF are available.
+    // Manual mode: all five controls.
+    let (num_cols, show_limiter_comp) = if ds.mode == InputMode::Auto {
+        (3usize, false)
+    } else {
+        (5usize, true)
+    };
+
+    let constraints: Vec<Constraint> = (0..num_cols)
+        .map(|_| Constraint::Ratio(1, num_cols as u32))
+        .collect();
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(constraints)
+        .margin(1)
+        .split(area);
+
+    let mut col = 0usize;
+
+    if show_limiter_comp {
+        // ── Limiter — identical to Gen 1 ─────────────────────────────────────
+        let lim_foc = app.focus == Focus::Limiter;
+        let lim_p = Paragraph::new(vec![
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("Status: ", Style::default().fg(C_DIM)),
+                bool_span(ds.limiter_enabled),
+            ]),
+            Line::from(""),
+            Line::from(Span::styled(
+                "Prevents clipping by",
+                Style::default().fg(C_DIM),
+            )),
+            Line::from(Span::styled(
+                "capping the output",
+                Style::default().fg(C_DIM),
+            )),
+            Line::from(Span::styled("level at 0 dBFS.", Style::default().fg(C_DIM))),
+            Line::from(""),
+            Line::from(Span::styled(
+                "[Enter] to toggle",
+                Style::default().fg(if lim_foc { C_FOCUS } else { C_DISABLED }),
+            )),
+        ])
+        .block(
+            Block::default()
+                .title(Span::styled(
+                    "  Limiter  ",
+                    if lim_foc {
+                        Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(C_TEXT)
+                    },
+                ))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(if lim_foc {
+                    Style::default().fg(C_FOCUS)
+                } else {
+                    Style::default().fg(C_BORDER)
+                })
+                .padding(Padding::horizontal(1)),
+        );
+        f.render_widget(lim_p, cols[col]);
+        col += 1;
+
+        // ── Compressor — identical to Gen 1 ──────────────────────────────────
+        let comp_foc = app.focus == Focus::Compressor;
+        let comp_lines: Vec<Line> = [
+            CompressorPreset::Off,
+            CompressorPreset::Light,
+            CompressorPreset::Medium,
+            CompressorPreset::Heavy,
+        ]
+        .iter()
+        .map(|preset| {
+            let selected = *preset == ds.compressor;
+            Line::from(vec![
+                Span::styled(
+                    if selected { "▶ " } else { "  " },
+                    Style::default().fg(C_ACCENT),
+                ),
+                Span::styled(
+                    preset.to_string(),
+                    if selected {
+                        Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(C_DIM)
+                    },
+                ),
+            ])
+        })
+        .collect();
+
+        let mut comp_content = vec![Line::from("")];
+        comp_content.extend(comp_lines);
+        comp_content.push(Line::from(""));
+        comp_content.push(Line::from(Span::styled(
+            "[Enter] to cycle",
+            Style::default().fg(if comp_foc { C_FOCUS } else { C_DISABLED }),
+        )));
+
+        let comp_p = Paragraph::new(comp_content).block(
+            Block::default()
+                .title(Span::styled(
+                    "  Compressor  ",
+                    if comp_foc {
+                        Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(C_TEXT)
+                    },
+                ))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(if comp_foc {
+                    Style::default().fg(C_FOCUS)
+                } else {
+                    Style::default().fg(C_BORDER)
+                })
+                .padding(Padding::horizontal(1)),
+        );
+        f.render_widget(comp_p, cols[col]);
+        col += 1;
+    }
+
+    // ── Denoiser — always visible ─────────────────────────────────────────────
+    let den_foc = app.focus == Focus::Denoiser;
+    let den_p = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(C_DIM)),
+            bool_span(ds.denoiser_enabled),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Reduces background",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(Span::styled(
+            "noise in real time.",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "[Enter] to toggle",
+            Style::default().fg(if den_foc { C_FOCUS } else { C_DISABLED }),
+        )),
+    ])
+    .block(
+        Block::default()
+            .title(Span::styled("  Denoiser  ", focused_style(den_foc)))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if den_foc {
+                Style::default().fg(C_FOCUS)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .padding(Padding::horizontal(1)),
+    );
+    f.render_widget(den_p, cols[col]);
+    col += 1;
+
+    // ── Popper Stopper — always visible ───────────────────────────────────────
+    let pop_foc = app.focus == Focus::PopperStopper;
+    let pop_p = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("Status: ", Style::default().fg(C_DIM)),
+            bool_span(ds.popper_stopper_enabled),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled("Reduces plosive", Style::default().fg(C_DIM))),
+        Line::from(Span::styled(
+            "sounds (p, b, t).",
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "[Enter] to toggle",
+            Style::default().fg(if pop_foc { C_FOCUS } else { C_DISABLED }),
+        )),
+    ])
+    .block(
+        Block::default()
+            .title(Span::styled("  Popper Stopper  ", focused_style(pop_foc)))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if pop_foc {
+                Style::default().fg(C_FOCUS)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .padding(Padding::horizontal(1)),
+    );
+    f.render_widget(pop_p, cols[col]);
+    col += 1;
+
+    // ── HPF — always visible ──────────────────────────────────────────────────
+    let hpf_foc = app.focus == Focus::Hpf;
+    let hpf_lines: Vec<Line> = [HpfFrequency::Off, HpfFrequency::Hz75, HpfFrequency::Hz150]
+        .iter()
+        .map(|freq| {
+            let selected = *freq == ds.hpf;
+            Line::from(vec![
+                Span::styled(
+                    if selected { "▶ " } else { "  " },
+                    Style::default().fg(C_ACCENT),
+                ),
+                Span::styled(
+                    freq.to_string(),
+                    if selected {
+                        Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(C_DIM)
+                    },
+                ),
+            ])
+        })
+        .collect();
+
+    let mut hpf_content = vec![Line::from("")];
+    hpf_content.extend(hpf_lines);
+    hpf_content.push(Line::from(""));
+    hpf_content.push(Line::from(Span::styled(
+        "[Enter] to cycle",
+        Style::default().fg(if hpf_foc { C_FOCUS } else { C_DISABLED }),
+    )));
+
+    let hpf_p = Paragraph::new(hpf_content).block(
+        Block::default()
+            .title(Span::styled(
+                "  High-Pass Filter  ",
+                if hpf_foc {
+                    Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(C_TEXT)
+                },
+            ))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(if hpf_foc {
+                Style::default().fg(C_FOCUS)
+            } else {
+                Style::default().fg(C_BORDER)
+            })
+            .padding(Padding::horizontal(1)),
+    );
+    f.render_widget(hpf_p, cols[col]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Tab locked / not-available notices
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -1404,6 +2044,10 @@ fn render_notice(f: &mut Frame, area: Rect, lines: Vec<Line>) {
 fn draw_eq_tab(f: &mut Frame, app: &App, area: Rect) {
     if app.device_model == DeviceModel::Mv6 {
         draw_mv6_eq_tab(f, app, area);
+        return;
+    }
+    if app.device_model == DeviceModel::Mvx2uGen2 {
+        draw_gen2_eq_tab(f, app, area);
         return;
     }
     if app.device_state.mode == InputMode::Auto {
@@ -1486,10 +2130,11 @@ fn draw_eq_tab(f: &mut Frame, app: &App, area: Rect) {
             C_BORDER
         };
 
-        // Vertical gain bar: −8 dB = bottom (row 0), +6 dB = top (row 7).
-        // Total span = 14 dB.  bar_pos = (gain + 8) * 7 / 14.
+        // Vertical gain bar: −8.0 dB = bottom (row 0), +6.0 dB = top (row 7).
+        // Total span = 14.0 dB. gain_db is in tenths, so range is −80..+60.
+        // bar_pos = (gain_db + 80) * 7 / 140.
         let bar_height: i32 = 7;
-        let bar_pos = ((band.gain_db as i32 + 8) * bar_height / 14)
+        let bar_pos = ((band.gain_db as i32 + 80) * bar_height / 140)
             .max(0)
             .min(bar_height);
 
@@ -1538,7 +2183,7 @@ fn draw_eq_tab(f: &mut Frame, app: &App, area: Rect) {
                     Style::default().fg(if gain_foc { C_FOCUS } else { C_DIM }),
                 ),
                 Span::styled(
-                    format!("{:+3} dB", band.gain_db),
+                    format!("{:+.1} dB", band.gain_db as f32 / 10.0),
                     if gain_foc {
                         Style::default().fg(C_FOCUS).add_modifier(Modifier::BOLD)
                     } else if band.gain_db > 0 {
@@ -1587,6 +2232,10 @@ fn draw_eq_tab(f: &mut Frame, app: &App, area: Rect) {
 fn draw_dynamics_tab(f: &mut Frame, app: &App, area: Rect) {
     if app.device_model == DeviceModel::Mv6 {
         draw_mv6_dynamics_tab(f, app, area);
+        return;
+    }
+    if app.device_model == DeviceModel::Mvx2uGen2 {
+        draw_gen2_dynamics_tab(f, app, area);
         return;
     }
     if app.device_state.mode == InputMode::Auto {
@@ -1950,6 +2599,7 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
 
     let (vid_pid, gain_range) = match model {
         DeviceModel::Mvx2u => ("14ED:1013", "0–60 dB"),
+        DeviceModel::Mvx2uGen2 => ("14ED:1033", "0–60 dB"),
         DeviceModel::Mv6 => ("14ED:1026", "0–36 dB"),
     };
 
@@ -2001,6 +2651,22 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
             ("  Monitor Mix  : ", "0–100%"),
             ("  Auto Level   : ", "On / Off"),
             ("  Config Lock  : ", "On / Off"),
+        ],
+        DeviceModel::Mvx2uGen2 => &[
+            ("  Phantom Pwr  : ", "48V"),
+            ("  EQ           : ", "5-band parametric"),
+            ("  HPF          : ", "Off / 75 Hz / 150 Hz"),
+            ("  Compressor   : ", "Off / Light / Medium / Heavy"),
+            ("  Limiter      : ", "On / Off"),
+            ("  Denoiser     : ", "On / Off"),
+            ("  Popper Stop. : ", "On / Off"),
+            (
+                "  Tone         : ",
+                "Dark (−100%) → Natural → Bright (+100%)",
+            ),
+            ("  Gain Lock    : ", "On / Off (Manual mode)"),
+            ("  Monitor Mix  : ", "0–100%"),
+            ("  Auto Level   : ", "On / Off"),
         ],
         DeviceModel::Mv6 => &[
             ("  Denoiser     : ", "On / Off"),


### PR DESCRIPTION
Adds full support for the Shure MVX2U Gen 2 audio interface, reverse- engineered via usbmon captures and probe sweeps against firmware on PID 0x1033.

-- Add MVX2U_GEN2_PID (0x1033) and DeviceModel::Mvx2uGen2
-- Gen 2 EQ gain uses 1-byte signed i8 wire encoding (vs Gen 1 i16 BE); same addresses, disambiguated in apply_response by response length
-- EqBand.gain_db promoted from i8 (whole dB) to i16 (tenths of dB) to support Gen 2's 0.5 dB step resolution without a separate field
-- SerEqBand.gain_db promoted to i16 for full preset round-trip fidelity
-- Gen 2 shares denoiser [01 58], gain lock [01 F3], tone [02 04], and popper stopper [03 81] with MV6 — confirmed by probe diff
-- Gen 2 monitor mix SET uses HDR_CONSTANT=0x00 (same framing as MV6)
-- Gen 2 has no config lock, no EQ master enable, no per-band enable — all confirmed absent by probe sweep (page 0x00 and [02 N0] silent)
-- Gen 2 EQ band center-frequency registers [02 N1] are read-only and match EQ_BAND_FREQS exactly; not fetched at runtime
-- Add get_state_mvx2u_gen2() fetching all applicable features
-- cmd_set_eq_band_gain now takes DeviceModel for wire format selection

-- Auto mode: Mode toggle, Mute, Monitor Mix, Phantom Power
-- Auto mode EQ tab: Tone slider (same as MV6)
-- Manual mode: Mode toggle, Mute, Gain (0–60 dB), Gain Lock, Monitor Mix, Phantom Power
-- Manual mode EQ tab: 5-band parametric EQ, 0.5 dB steps, no master enable, no per-band enable toggle
-- Dynamics tab (both modes): Denoiser, Popper Stopper, HPF
-- Dynamics tab (Manual only): Limiter, Compressor
-- EQ and Dynamics tabs remain accessible in Auto mode (unlike Gen 1)
-- Flat EQ keybinding (f) added for both Gen 1 and Gen 2

-- Gen 2 main tab mirrors MVX2U conventions with gain lock (Manual) and phantom power visible in both modes
-- Gen 2 EQ tab uses same visual style as Gen 1 (vertical bar, band cards) with decimal dB display (+0.5 dB resolution)
-- Gen 1 EQ tab gain display updated to decimal dB (was whole number) as a result of the EqBand.gain_db type change
-- Gen 2 Dynamics tab uses identical verbiage to Gen 1 for shared controls (Limiter, Compressor, HPF)
-- Summary panel is mode-aware: Tone shown in Auto, Gain Lock shown in Manual; applied to both Gen 2 and MV6
-- Info tab updated with Gen 2 capabilities and USB VID/PID
-- KNOWN_FEATURES updated to reflect confirmed Gen 2 presence/absence of each address; "verify with diff" notes removed

Preset files saved by earlier versions will load EQ gain values as tenths of dB rather than whole dB (e.g. saved "-4" loads as -0.4 dB). Users should resave presets after upgrading.