### PR TITLE
fix: hide Reverb and LED tabs for non-MV7+ devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shurectl"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -123,7 +123,21 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
-    let titles: Vec<Line> = Tab::ALL
+    // Permanently locked tabs (Reverb, LED on non-MV7+ devices) are hidden
+    // entirely — they have no meaning for those devices. Temporarily locked
+    // tabs (EQ, Dynamics on MVX2U Gen 1 in Auto mode) remain visible with a
+    // lock icon since they're meaningful but currently inaccessible.
+    let visible: Vec<Tab> = Tab::ALL
+        .iter()
+        .copied()
+        .filter(|t| {
+            let permanently_locked = matches!(t, Tab::Reverb | Tab::Led)
+                && app.device_model != crate::protocol::DeviceModel::Mv7Plus;
+            !permanently_locked
+        })
+        .collect();
+
+    let titles: Vec<Line> = visible
         .iter()
         .map(|t| {
             if app.is_tab_locked(*t) {
@@ -137,8 +151,13 @@ fn draw_tabs(f: &mut Frame, app: &App, area: Rect) {
         })
         .collect();
 
+    let selected = visible
+        .iter()
+        .position(|t| *t == app.active_tab)
+        .unwrap_or(0);
+
     let tabs = Tabs::new(titles)
-        .select(app.active_tab.index())
+        .select(selected)
         .block(
             Block::default()
                 .borders(Borders::BOTTOM)


### PR DESCRIPTION
Reverb and LED tabs are MV7+-exclusive and have no meaning for MVX2U, MVX2U Gen 2, or MV6. Hide them from the tab bar entirely rather than showing them locked.

Temporarily locked tabs (EQ, Dynamics on MVX2U Gen 1 in Auto mode) are unaffected — they remain visible with a lock icon since they are meaningful for that device.