### PR TITLE
fix: correct udev rule filename and SUBSYSTEM keyword in README

### DIFF
--- a/62-shure.rules
+++ b/62-shure.rules
@@ -3,8 +3,11 @@
 # No group membership required.
 # Install to: /etc/udev/rules.d/62-shure.rules
 # Then run: sudo udevadm control --reload-rules && sudo udevadm trigger
-# Note: You may need SUBSYSTEMS or SUBSYSTEM based on your linux distro
 # MVX2U Gen 1
 ACTION!="remove", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"
+# MVX2U Gen 2
+ACTION!="remove", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1033", TAG+="uaccess"
 # MV6
 ACTION!="remove", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1026", TAG+="uaccess"
+# MV7+
+ACTION!="remove", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1019", TAG+="uaccess"

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ interfaces and microphones on Linux and macOS. Replaces the Windows/Mac-only Shu
 
 Without a udev rule, `/dev/hidrawN` for the device is only accessible by root.
 
-Create `/etc/udev/rules.d/62-shurectl.rules`:
+Create `/etc/udev/rules.d/62-shure.rules`:
 
 ```
-ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"
-ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1033", TAG+="uaccess"
-ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1026", TAG+="uaccess"
-ACTION!="remove", SUBSYSTEMS=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1019", TAG+="uaccess"
+ACTION!="remove", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1013", TAG+="uaccess"
+ACTION!="remove", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1033", TAG+="uaccess"
+ACTION!="remove", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1026", TAG+="uaccess"
+ACTION!="remove", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="14ed", ATTRS{idProduct}=="1019", TAG+="uaccess"
 ```
 
 Then reload udev and replug your device:


### PR DESCRIPTION
62-shurectl.rules → 62-shure.rules to match the actual file in the repo.
SUBSYSTEMS → SUBSYSTEM; the hidraw device node is directly in the hidraw
subsystem so the singular form is correct and consistent with the .rules file.