### PR TITLE
Add Windows support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
 # shurectl — Project Instructions
 
 The goal of this project is to build and maintain **shurectl**, an open-source terminal UI
-configurator for Shure USB audio interfaces (MVX2U Gen 1/Gen 2, MV6, and MV7+) on Linux
-and macOS. It replaces the Windows/Mac-only ShurePlus MOTIV Desktop app by communicating
-with devices directly over USB HID.
+configurator for Shure USB audio interfaces (MVX2U Gen 1/Gen 2, MV6, and MV7+) on Linux,
+macOS, and Windows. It replaces the Windows/Mac-only ShurePlus MOTIV Desktop app by
+communicating with devices directly over USB HID.
 
 This is a Rust project. Operate as a senior Rust developer: write clean, readable, maintainable
 code. Avoid clever abstractions. The simple, obvious solution is almost always correct.
@@ -97,7 +97,8 @@ exactly 64 bytes, sent via `hid_write()` and received via `hid_read()`:
 - **Report ID**: `0x01` — required as byte 0 by hidapi's `hid_write()`; our buffers are 65 bytes total (1 report ID + 64 payload)
 - **CRC**: CRC-16/ANSI — poly `0x8005`, init `0x0000`, reflected input and output (NOT CCITT-FALSE)
 - **Transport**: plain HID Output Reports (`hid_write`) for commands; Input Reports (`hid_read`) for responses — `HIDIOCSFEATURE`/`HIDIOCGFEATURE` are NOT used
-- **Interface**: accessed via `/dev/hidrawN`, not the USB audio class interface
+- **Interface**: accessed via `/dev/hidrawN` on Linux (Windows uses `\\?\HID#VID_...` paths), not the USB audio class interface
+- **Windows HID collections**: Windows enumerates each top-level HID collection as a separate device path, so one mic appears as two entries. The config protocol lives on the vendor collection (usage page `0xFF01`); the second is a telephony/consumer collection (`0x000B`) for the mute button. `device.rs::shure_devices()` filters to the vendor usage-page collection. On Linux all collections share one `/dev/hidrawN` path and dedup-by-path collapses them, so the filter is a harmless refinement there.
 - **SET + CONFIRM**: every SET command must be immediately followed by a CONFIRM packet (`CMD_CONFIRM`); the device will not apply the change without it
 
 All command byte values and feature address constants live in `protocol.rs`.
@@ -227,9 +228,10 @@ This is intentional: demo mode should always be fully navigable.
 
 - `ratatui 0.30` — TUI rendering; use `Frame::render_widget()`, not direct buffer writes
 - `crossterm 0.29` — terminal backend and key events; `KeyEventKind::Press` only
-- `hidapi 2.4` (linux-native feature) — HID device open/read/write via `/dev/hidrawN`
+- `hidapi 2.4` — HID device open/read/write. Per-OS features: `linux-native` (`/dev/hidrawN`),
+  `macos-shared-device`, and the default Windows backend (HID paths like `\\?\HID#VID_...`)
 - `cpal 0.17` — audio capture for the input level meter; default input device only
-- `libc 0.2` — stderr suppression during cpal ALSA/JACK probing (`dup`/`dup2`)
+- `libc 0.2` (unix only) — stderr suppression during cpal ALSA/JACK probing (`dup`/`dup2`)
 - `anyhow` — all fallible functions return `anyhow::Result`
 - `clap 4.5` — CLI argument parsing; `derive` feature only
 - `serde 1` (with `derive` feature) — serialisation traits for preset TOML files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ This is intentional: demo mode should always be fully navigable.
 - `crossterm 0.29` — terminal backend and key events; `KeyEventKind::Press` only
 - `hidapi 2.4` — HID device open/read/write. Per-OS features: `linux-native` (`/dev/hidrawN`), `macos-shared-device` (IOKit), and default Windows backend (`\\.\HID#VID_...`)
 - `cpal 0.17` — audio capture for the input level meter; default input device only
-- `libc 0.2` (unix only) — stderr suppression during cpal ALSA/JACK probing (`dup`/`dup2`)
+- `libc 0.2` (Unix only) — stderr suppression during cpal ALSA/JACK probing (`dup`/`dup2`)
 - `anyhow` — all fallible functions return `anyhow::Result`
 - `clap 4.5` — CLI argument parsing; `derive` feature only
 - `serde 1` (with `derive` feature) — serialisation traits for preset TOML files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,9 @@
 # shurectl — Project Instructions
 
 The goal of this project is to build and maintain **shurectl**, an open-source terminal UI
-configurator for Shure USB audio interfaces (MVX2U Gen 1/Gen 2, MV6, and MV7+) on Linux,
-macOS, and Windows. It replaces the Windows/Mac-only ShurePlus MOTIV Desktop app by
-communicating with devices directly over USB HID.
+configurator for Shure USB audio interfaces (MVX2U Gen 1/Gen 2, MV6, and MV7+) on Linux
+and macOS. It replaces the Windows/Mac-only ShurePlus MOTIV Desktop app by communicating
+with devices directly over USB HID.
 
 This is a Rust project. Operate as a senior Rust developer: write clean, readable, maintainable
 code. Avoid clever abstractions. The simple, obvious solution is almost always correct.
@@ -97,8 +97,7 @@ exactly 64 bytes, sent via `hid_write()` and received via `hid_read()`:
 - **Report ID**: `0x01` — required as byte 0 by hidapi's `hid_write()`; our buffers are 65 bytes total (1 report ID + 64 payload)
 - **CRC**: CRC-16/ANSI — poly `0x8005`, init `0x0000`, reflected input and output (NOT CCITT-FALSE)
 - **Transport**: plain HID Output Reports (`hid_write`) for commands; Input Reports (`hid_read`) for responses — `HIDIOCSFEATURE`/`HIDIOCGFEATURE` are NOT used
-- **Interface**: accessed via `/dev/hidrawN` on Linux (Windows uses `\\?\HID#VID_...` paths), not the USB audio class interface
-- **Windows HID collections**: Windows enumerates each top-level HID collection as a separate device path, so one mic appears as two entries. The config protocol lives on the vendor collection (usage page `0xFF01`); the second is a telephony/consumer collection (`0x000B`) for the mute button. `device.rs::shure_devices()` filters to the vendor usage-page collection. On Linux all collections share one `/dev/hidrawN` path and dedup-by-path collapses them, so the filter is a harmless refinement there.
+- **Interface**: accessed via `/dev/hidrawN`, not the USB audio class interface
 - **SET + CONFIRM**: every SET command must be immediately followed by a CONFIRM packet (`CMD_CONFIRM`); the device will not apply the change without it
 
 All command byte values and feature address constants live in `protocol.rs`.
@@ -228,8 +227,7 @@ This is intentional: demo mode should always be fully navigable.
 
 - `ratatui 0.30` — TUI rendering; use `Frame::render_widget()`, not direct buffer writes
 - `crossterm 0.29` — terminal backend and key events; `KeyEventKind::Press` only
-- `hidapi 2.4` — HID device open/read/write. Per-OS features: `linux-native` (`/dev/hidrawN`),
-  `macos-shared-device`, and the default Windows backend (HID paths like `\\?\HID#VID_...`)
+- `hidapi 2.4` — HID device open/read/write. Per-OS features: `linux-native` (`/dev/hidrawN`), `macos-shared-device` (IOKit), and default Windows backend (`\\.\HID#VID_...`)
 - `cpal 0.17` — audio capture for the input level meter; default input device only
 - `libc 0.2` (unix only) — stderr suppression during cpal ALSA/JACK probing (`dup`/`dup2`)
 - `anyhow` — all fallible functions return `anyhow::Result`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shurectl"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2024"
 description = "shurectl — TUI configurator for the Shure MVX2U audio interface"
 
@@ -19,6 +19,8 @@ toml = "0.8"
 dirs-next = "2.0"
 
 [target.'cfg(unix)'.dependencies]
+# libc is used solely for the stderr suppressor in meter.rs (dup/dup2).
+# WASAPI on Windows does not spam stderr during device probing, so it is not needed there.
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -28,6 +30,7 @@ hidapi = { version = "2.4.1", default-features = false, features = ["linux-nativ
 hidapi = { version = "2.4.1", default-features = false, features = ["macos-shared-device"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+# Default features pull in the Windows HID backend (setupapi) via the bundled hidapi C library.
 hidapi = "2.4.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,21 @@ crossterm = "0.29"
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
 cpal = "0.17"
-libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 dirs-next = "2.0"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 hidapi = { version = "2.4.1", default-features = false, features = ["linux-native"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 hidapi = { version = "2.4.1", default-features = false, features = ["macos-shared-device"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+hidapi = "2.4.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # shurectl
 
 An open-source terminal UI configurator for the Shure XLR-to-USB audio
-interfaces and microphones on Linux, macOS, and Windows. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
+interfaces and microphones on Linux and macOS. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
 
 ![Project Example Screenshot](images/shurectl.png)
 
@@ -92,17 +92,6 @@ shurectl --list
 On macOS, IOKit grants user-space access to HID devices without extra configuration.
 Plug in your device and run `shurectl --list` to confirm detection.
 
-### Windows — No Extra Setup Required
-
-Windows grants user-space HID access out of the box. Plug in your device and run
-`shurectl --list` to confirm detection. Device paths look like
-`\\?\HID#VID_14ED&PID_1026&...` rather than `/dev/hidrawN`.
-
-Building from source needs the MSVC toolchain (the default `rustup` host on Windows)
-and the Microsoft C++ Build Tools with the "MSVC v143 x64/x86 build tools" and
-"Windows SDK" components. Build from a "Developer PowerShell for VS" so the linker is
-on `PATH`.
-
 ---
 
 ## Installing
@@ -192,7 +181,7 @@ On the **Presets tab**:
 ## Troubleshooting
 
 **"Cannot open device"** — device not found or a permissions issue.
-Run `shurectl --list` to check detection. On Linux, try `sudo shurectl` to confirm it's a udev permissions issue. On macOS and Windows, ensure no other software (e.g. ShurePlus MOTIV) has exclusive access to the device.
+Run `shurectl --list` to check detection. On Linux, try `sudo shurectl` to confirm it's a udev permissions issue. On macOS, ensure no other software has exclusive access to the device.
 
 **Gain slider is greyed out in Auto Level mode** — This is correct hardware behaviour;
 the device ignores gain commands in Auto Level mode. Switch to Manual mode first.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # shurectl
 
 An open-source terminal UI configurator for the Shure XLR-to-USB audio
-interfaces and microphones on Linux and macOS. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
+interfaces and microphones on Linux, macOS, and Windows. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
 
 ![Project Example Screenshot](images/shurectl.png)
 
@@ -92,6 +92,17 @@ shurectl --list
 On macOS, IOKit grants user-space access to HID devices without extra configuration.
 Plug in your device and run `shurectl --list` to confirm detection.
 
+### Windows — No Extra Setup Required
+
+Windows grants user-space HID access out of the box. Plug in your device and run
+`shurectl --list` to confirm detection. Device paths look like
+`\\?\HID#VID_14ED&PID_1026&...` rather than `/dev/hidrawN`.
+
+Building from source needs the MSVC toolchain (the default `rustup` host on Windows)
+and the Microsoft C++ Build Tools with the "MSVC v143 x64/x86 build tools" and
+"Windows SDK" components. Build from a "Developer PowerShell for VS" so the linker is
+on `PATH`.
+
 ---
 
 ## Installing
@@ -181,7 +192,7 @@ On the **Presets tab**:
 ## Troubleshooting
 
 **"Cannot open device"** — device not found or a permissions issue.
-Run `shurectl --list` to check detection. On Linux, try `sudo shurectl` to confirm it's a udev permissions issue. On macOS, ensure no other software has exclusive access to the device.
+Run `shurectl --list` to check detection. On Linux, try `sudo shurectl` to confirm it's a udev permissions issue. On macOS and Windows, ensure no other software (e.g. ShurePlus MOTIV) has exclusive access to the device.
 
 **Gain slider is greyed out in Auto Level mode** — This is correct hardware behaviour;
 the device ignores gain commands in Auto Level mode. Switch to Manual mode first.

--- a/src/device.rs
+++ b/src/device.rs
@@ -104,13 +104,7 @@ impl ShureDevice {
     pub fn open() -> Result<Self> {
         let api = HidApi::new().context("Failed to initialise hidapi")?;
 
-        // Deduplicate by path — some devices expose multiple HID interfaces
-        // and hidapi enumerates each one separately under the same path.
-        let mut seen_paths = std::collections::HashSet::new();
-        let found: Vec<_> = api
-            .device_list()
-            .filter(|d| is_shure_device(d, &mut seen_paths))
-            .collect();
+        let found = shure_devices(&api);
 
         match found.len() {
             0 => Err(anyhow!(
@@ -653,20 +647,46 @@ pub struct DeviceInfo {
     pub model: DeviceModel,
 }
 
-/// Returns `true` if `d` is a supported Shure device that has not been seen before.
+/// Lowest usage page in the HID vendor-defined range (0xFF00–0xFFFF).
 ///
-/// `seen_paths` is used to deduplicate entries — hidapi may enumerate the same
-/// physical device multiple times when it exposes more than one HID interface.
-fn is_shure_device(
-    d: &hidapi::DeviceInfo,
-    seen_paths: &mut std::collections::HashSet<String>,
-) -> bool {
-    d.vendor_id() == VID
-        && (d.product_id() == PID
-            || d.product_id() == MVX2U_GEN2_PID
-            || d.product_id() == MV6_PID
-            || d.product_id() == MV7_PLUS_PID)
-        && seen_paths.insert(d.path().to_string_lossy().into_owned())
+/// Shure exposes its configuration protocol on a vendor-defined collection
+/// (usage page 0xFF01 on the MV6). The same physical interface also carries a
+/// telephony/consumer collection (usage page 0x000B) for the hardware mute
+/// button. On Windows each top-level collection enumerates as a separate device
+/// path, so we must pick the vendor collection and ignore the mute-button one.
+/// On Linux every collection shares the same `/dev/hidrawN` path and dedup by
+/// path already collapses them, so this filter is a harmless refinement there.
+const VENDOR_USAGE_PAGE_MIN: u16 = 0xFF00;
+
+fn is_supported_pid(pid: u16) -> bool {
+    pid == PID || pid == MVX2U_GEN2_PID || pid == MV6_PID || pid == MV7_PLUS_PID
+}
+
+/// Enumerate supported Shure devices, one entry per physical device.
+///
+/// Two passes: first restrict to the vendor configuration collection if any
+/// candidate advertises a vendor usage page (drops the Windows telephony
+/// collection), then deduplicate by path so a device exposing several HID
+/// interfaces under the same path is only counted once.
+fn shure_devices(api: &HidApi) -> Vec<&hidapi::DeviceInfo> {
+    let candidates: Vec<&hidapi::DeviceInfo> = api
+        .device_list()
+        .filter(|d| d.vendor_id() == VID && is_supported_pid(d.product_id()))
+        .collect();
+
+    // Some Linux backends report usage_page=0 (descriptor not parsed). In that
+    // case no candidate looks like a vendor collection, so keep them all and let
+    // path dedup do the work.
+    let has_vendor = candidates
+        .iter()
+        .any(|d| d.usage_page() >= VENDOR_USAGE_PAGE_MIN);
+
+    let mut seen_paths = std::collections::HashSet::new();
+    candidates
+        .into_iter()
+        .filter(|d| !has_vendor || d.usage_page() >= VENDOR_USAGE_PAGE_MIN)
+        .filter(|d| seen_paths.insert(d.path().to_string_lossy().into_owned()))
+        .collect()
 }
 
 /// Probe the system for supported Shure devices without opening them.
@@ -674,9 +694,8 @@ pub fn list_devices() -> Vec<DeviceInfo> {
     let Ok(api) = HidApi::new() else {
         return vec![];
     };
-    let mut seen_paths = std::collections::HashSet::new();
-    api.device_list()
-        .filter(|d| is_shure_device(d, &mut seen_paths))
+    shure_devices(&api)
+        .into_iter()
         .map(|d| DeviceInfo {
             path: d.path().to_string_lossy().into_owned(),
             serial: d.serial_number().unwrap_or("(unknown)").to_owned(),

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,9 +6,9 @@
 //!   - Shure MV6         (VID 0x14ED, PID 0x1026) — USB gaming microphone
 //!   - Shure MV7+        (VID 0x14ED, PID 0x1019) — USB/XLR dynamic microphone (protocol unverified)
 //!
-//! Both devices expose a USB HID configuration interface alongside their
-//! audio interface. hidapi opens the HID interface via /dev/hidrawN on Linux,
-//! bypassing the audio driver entirely.
+//! All four devices expose a USB HID configuration interface alongside their
+//! audio interface. hidapi opens it via /dev/hidrawN on Linux, IOKit on macOS,
+//! and \\.\HID#VID_... paths on Windows, bypassing the audio driver entirely.
 //!
 //! # Transport
 //!
@@ -58,7 +58,10 @@ use crate::protocol::{
 
 #[cfg(target_os = "linux")]
 const ACCESS_HINT: &str = "ensure the udev rule is installed, or run with sudo";
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")]
+const ACCESS_HINT: &str =
+    "ensure no other software (e.g. ShurePlus MOTIV) has exclusive access to the device";
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
 const ACCESS_HINT: &str = "ensure the device is plugged in and accessible";
 
 /// How long to wait for a read response, in milliseconds.
@@ -103,7 +106,6 @@ impl ShureDevice {
     /// Use `--device` to select a specific device when multiple are present.
     pub fn open() -> Result<Self> {
         let api = HidApi::new().context("Failed to initialise hidapi")?;
-
         let found = shure_devices(&api);
 
         match found.len() {
@@ -138,9 +140,7 @@ impl ShureDevice {
             })?;
 
         let pid = info.product_id();
-        if info.vendor_id() != VID
-            || (pid != PID && pid != MV6_PID && pid != MVX2U_GEN2_PID && pid != MV7_PLUS_PID)
-        {
+        if info.vendor_id() != VID || !is_supported_pid(pid) {
             return Err(anyhow!(
                 "{path} is not a supported Shure device \
                 (VID={:#06x} PID={:#06x}); expected VID={:#06x} with PID={:#06x}, {:#06x}, {:#06x}, or {:#06x}.",
@@ -647,36 +647,30 @@ pub struct DeviceInfo {
     pub model: DeviceModel,
 }
 
-/// Lowest usage page in the HID vendor-defined range (0xFF00–0xFFFF).
-///
-/// Shure exposes its configuration protocol on a vendor-defined collection
-/// (usage page 0xFF01 on the MV6). The same physical interface also carries a
-/// telephony/consumer collection (usage page 0x000B) for the hardware mute
-/// button. On Windows each top-level collection enumerates as a separate device
-/// path, so we must pick the vendor collection and ignore the mute-button one.
-/// On Linux every collection shares the same `/dev/hidrawN` path and dedup by
-/// path already collapses them, so this filter is a harmless refinement there.
-const VENDOR_USAGE_PAGE_MIN: u16 = 0xFF00;
-
+/// Returns `true` if `pid` is one of the four supported Shure device PIDs.
 fn is_supported_pid(pid: u16) -> bool {
     pid == PID || pid == MVX2U_GEN2_PID || pid == MV6_PID || pid == MV7_PLUS_PID
 }
 
 /// Enumerate supported Shure devices, one entry per physical device.
 ///
-/// Two passes: first restrict to the vendor configuration collection if any
-/// candidate advertises a vendor usage page (drops the Windows telephony
-/// collection), then deduplicate by path so a device exposing several HID
-/// interfaces under the same path is only counted once.
+/// Two-pass approach:
+/// 1. Filter to VID/PID candidates.
+/// 2. If any candidate advertises a vendor-defined HID usage page (0xFF00–0xFFFF),
+///    restrict to those — this drops the Windows telephony/mute-button collection
+///    (usage page 0x000B) that appears as a phantom second entry on Windows.
+///    Linux backends sometimes report usage_page=0 (descriptor not parsed); in
+///    that case no candidate looks vendor-defined, so all are kept and step 3
+///    handles deduplication.
+/// 3. Deduplicate by path — on Linux all collections share one /dev/hidrawN path.
+const VENDOR_USAGE_PAGE_MIN: u16 = 0xFF00;
+
 fn shure_devices(api: &HidApi) -> Vec<&hidapi::DeviceInfo> {
     let candidates: Vec<&hidapi::DeviceInfo> = api
         .device_list()
         .filter(|d| d.vendor_id() == VID && is_supported_pid(d.product_id()))
         .collect();
 
-    // Some Linux backends report usage_page=0 (descriptor not parsed). In that
-    // case no candidate looks like a vendor collection, so keep them all and let
-    // path dedup do the work.
     let has_vendor = candidates
         .iter()
         .any(|d| d.usage_page() >= VENDOR_USAGE_PAGE_MIN);

--- a/src/meter.rs
+++ b/src/meter.rs
@@ -210,9 +210,11 @@ pub fn start_meter(level: Arc<AtomicI32>, peak_window: Arc<Mutex<PeakWindow>>) -
 /// with Rust's I/O machinery. We never write to stderr ourselves inside the
 /// suppression window, so there is no risk of losing our own error output.
 struct StderrSuppressor {
+    #[cfg(unix)]
     saved_fd: i32,
 }
 
+#[cfg(unix)]
 impl StderrSuppressor {
     fn new() -> Self {
         // SAFETY: dup(2) duplicates the stderr fd; we check for failure.
@@ -229,6 +231,7 @@ impl StderrSuppressor {
     }
 }
 
+#[cfg(unix)]
 impl Drop for StderrSuppressor {
     fn drop(&mut self) {
         if self.saved_fd >= 0 {
@@ -239,6 +242,22 @@ impl Drop for StderrSuppressor {
             }
         }
     }
+}
+
+// cpal's WASAPI backend on Windows does not spam stderr during device
+// enumeration, so there is nothing to suppress. The no-op keeps start_meter()
+// platform-agnostic. The empty Drop mirrors the unix RAII guard so the early
+// drop() calls in start_meter() stay meaningful on every platform.
+#[cfg(not(unix))]
+impl StderrSuppressor {
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(not(unix))]
+impl Drop for StderrSuppressor {
+    fn drop(&mut self) {}
 }
 
 // ── Stream builder ────────────────────────────────────────────────────────────

--- a/src/meter.rs
+++ b/src/meter.rs
@@ -206,9 +206,12 @@ pub fn start_meter(level: Arc<AtomicI32>, peak_window: Arc<Mutex<PeakWindow>>) -
 /// hook available to suppress them. The suppression window is kept as short as
 /// possible — only the probing calls, not stream construction or playback.
 ///
-/// Safety: `dup` / `dup2` / `open` are async-signal-safe and do not interact
-/// with Rust's I/O machinery. We never write to stderr ourselves inside the
-/// suppression window, so there is no risk of losing our own error output.
+/// On Windows, cpal's WASAPI backend does not write to stderr during probing,
+/// so the non-unix impl is a no-op that keeps `start_meter()` unconditional.
+///
+/// Safety (unix): `dup` / `dup2` / `open` are async-signal-safe and do not
+/// interact with Rust's I/O machinery. We never write to stderr ourselves
+/// inside the suppression window, so there is no risk of losing our own output.
 struct StderrSuppressor {
     #[cfg(unix)]
     saved_fd: i32,
@@ -244,10 +247,6 @@ impl Drop for StderrSuppressor {
     }
 }
 
-// cpal's WASAPI backend on Windows does not spam stderr during device
-// enumeration, so there is nothing to suppress. The no-op keeps start_meter()
-// platform-agnostic. The empty Drop mirrors the unix RAII guard so the early
-// drop() calls in start_meter() stay meaningful on every platform.
 #[cfg(not(unix))]
 impl StderrSuppressor {
     fn new() -> Self {


### PR DESCRIPTION
## What this does

shurectl now builds and runs on Windows alongside Linux and macOS, over the same USB HID protocol.

## Changes

- `Cargo.toml` - add the Windows `hidapi` backend as a target dependency, move `libc` under `cfg(unix)` (it is only used for the stderr trick below)
- `meter.rs` - `StderrSuppressor` is unix-only; on Windows it is a no-op, since the WASAPI capture backend does not write to stderr during device probing
- `device.rs` - on Windows each top-level HID collection enumerates as its own device path, so a single mic showed up twice. Filter to the vendor config collection (usage page `0xFF01`) and ignore the telephony/mute-button collection (`0x000B`). On Linux every collection shares one `/dev/hidrawN` path, so this is a no-op there.

No protocol changes. Linux/macOS behaviour is unchanged: the dependency and meter changes are cfg-gated, and the device filter only ever drops the Windows phantom entry.

## Build notes (Windows)

Needs the MSVC toolchain and the Microsoft C++ Build Tools (MSVC + Windows SDK). Build from a Developer PowerShell for VS.

## Tested

Built and ran on Windows 11 against an MV6: `--list` shows one device, and state read/write works over HID (gain, mute, HPF, denoiser confirmed). Linux/macOS builds are preserved by cfg-gating; I only have Windows hardware to test on.
