### PR TITLE
Toggle mute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shurectl"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "shurectl"
-version = "2.3.1"
+version = "2.4.0"
 edition = "2024"
-description = "shurectl — TUI configurator for the Shure MVX2U audio interface"
+description = "shurectl — TUI configurator for Shure USB audio interfaces and microphones"
 
 [[bin]]
 name = "shurectl"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # shurectl
 
-An open-source terminal UI configurator for the Shure XLR-to-USB audio
-interfaces and microphones on Linux, macOS, and Windows. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
+An open-source terminal UI configurator for Shure USB audio interfaces and microphones on Linux, macOS, and Windows. Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app.
 
 ![Project Example Screenshot](images/shurectl.png)
 
@@ -87,21 +86,20 @@ shurectl --list
 #   /dev/hidraw2 | Shure MVX2U Gen 2 | S/N: MVX2U GEN 2#2-a646351d...
 ```
 
-### macOS — No Extra Setup Required
+### macOS — No Runtime Setup Required
 
 On macOS, IOKit grants user-space access to HID devices without extra configuration.
 Plug in your device and run `shurectl --list` to confirm detection.
 
-### Windows — No Extra Setup Required
+### Windows — No Runtime Setup Required
 
-Windows grants user-space HID access out of the box. Plug in your device and run
-`shurectl --list` to confirm detection. Device paths look like
-`\\?\HID#VID_14ED&PID_1026&...` rather than `/dev/hidrawN`.
+Windows grants user-space HID access out of the box via the `setupapi` backend — no driver installation or equivalent of a udev rule is needed. Plug in your device and run `shurectl --list` to confirm detection. Device paths look like `\\?\HID#VID_14ED&PID_1026&...` rather than `/dev/hidrawN`.
 
-Building from source needs the MSVC toolchain (the default `rustup` host on Windows)
-and the Microsoft C++ Build Tools with the "MSVC v143 x64/x86 build tools" and
-"Windows SDK" components. Build from a "Developer PowerShell for VS" so the linker is
-on `PATH`.
+Building from source requires the MSVC toolchain. Install [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the "Desktop development with C++" workload, then ensure MSVC is your active rustup toolchain:
+
+```
+rustup default stable-x86_64-pc-windows-msvc
+```
 
 ---
 
@@ -144,6 +142,9 @@ shurectl                         # Connect to first detected device and launch T
 shurectl --device <path>         # Connect to a specific device (use --list to find paths)
 shurectl --demo                  # Run without a device (explore the UI)
 shurectl --list                  # List detected Shure devices and exit
+shurectl --mute                  # Toggle mute without launching the TUI
+shurectl --mute on               # Mute
+shurectl --mute off              # Unmute
 ```
 
 ### Keyboard Shortcuts

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-//! shurectl — Interactive TUI configurator for Shure USB microphones
+//! shurectl — Interactive TUI configurator for Shure USB audio interfaces and microphones
 //!
 //! Supports:
 //!   - Shure MVX2U Gen 1 (XLR-to-USB audio interface)
 //!   - Shure MVX2U Gen 2 (XLR-to-USB interface with updated DSP)
 //!   - Shure MV6          (USB gaming microphone)
+//!   - Shure MV7+         (USB/XLR dynamic microphone)
 //!
 //! Usage:
 //!   shurectl                   # Connect to device, launch TUI
@@ -12,6 +13,9 @@
 //!   shurectl --demo mvx2u-gen2 # Demo MVX2U Gen 2 without a device
 //!   shurectl --list            # List detected devices and exit
 //!   shurectl --device PATH     # Open a specific device by HID path
+//!   shurectl --mute            # Toggle mute (no TUI)
+//!   shurectl --mute on         # Mute (no TUI)
+//!   shurectl --mute off        # Unmute (no TUI)
 
 mod app;
 mod device;
@@ -24,7 +28,7 @@ use std::io;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
@@ -39,11 +43,37 @@ use meter::{MeterStatus, start_meter};
 use presets::PresetSlot;
 use protocol::{DeviceModel, InputMode};
 
+/// Mute action for the `--mute` flag.
+#[derive(Debug, Clone, PartialEq)]
+enum MuteAction {
+    /// Flip the current mute state.
+    Toggle,
+    /// Mute the microphone.
+    On,
+    /// Unmute the microphone.
+    Off,
+}
+
+impl std::str::FromStr for MuteAction {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "toggle" => Ok(MuteAction::Toggle),
+            "on" => Ok(MuteAction::On),
+            "off" => Ok(MuteAction::Off),
+            other => anyhow::bail!(
+                "unknown mute action \"{other}\". Valid options: toggle, on, off"
+            ),
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(
     name = "shurectl",
     version,
-    about = "shurectl — TUI configurator for Shure MVX2U, MVX2U Gen 2, and MV6 USB microphones"
+    about = "shurectl — TUI configurator for Shure USB audio interfaces and microphones"
 )]
 struct Cli {
     /// Run in demo mode without a real device.
@@ -60,15 +90,25 @@ struct Cli {
     /// Use --list to see available paths.
     #[arg(long, short = 'D')]
     device: Option<String>,
+
+    /// Set mute state without launching the TUI.
+    /// toggle (default): flip current state. on: mute. off: unmute.
+    #[arg(long, short = 'm', num_args = 0..=1, default_missing_value = "toggle", value_name = "ACTION")]
+    mute: Option<MuteAction>,
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    if let Some(action) = cli.mute {
+        let path = cli.device.as_deref();
+        return cmd_mute(action, path);
+    }
+
     if cli.list {
         let devs = device::list_devices();
         if devs.is_empty() {
-            println!("No Shure MVX2U, MVX2U Gen 2, or MV6 devices found.");
+            println!("No supported Shure devices found.");
             #[cfg(target_os = "linux")]
             println!("Check that the device is plugged in and the udev rule is installed.");
             #[cfg(not(target_os = "linux"))]
@@ -173,6 +213,30 @@ fn main() -> Result<()> {
         eprintln!("Error: {e}");
     }
 
+    Ok(())
+}
+
+/// Apply a mute action to the connected device without launching the TUI.
+///
+/// Opens the device (or the specific path if `--device` was given), reads
+/// current state to resolve `Toggle`, then sends a single `set_mute()`.
+/// Prints the resulting state to stdout so the caller can see what happened.
+fn cmd_mute(action: MuteAction, device_path: Option<&str>) -> Result<()> {
+    let dev = match device_path {
+        Some(path) => ShureDevice::open_path(path),
+        None => ShureDevice::open(),
+    }
+    .context("Could not open device")?;
+
+    let muted = if action == MuteAction::Toggle {
+        let state = dev.get_state().context("Could not read device state")?;
+        !state.muted
+    } else {
+        action == MuteAction::On
+    };
+
+    dev.set_mute(muted).context("Could not set mute")?;
+    println!("Mute → {}", if muted { "ON" } else { "OFF" });
     Ok(())
 }
 


### PR DESCRIPTION
feat: add --mute flag for headless mute control
Adds -m/--mute [ACTION] to toggle mute without launching the TUI.
Useful for hotkey and stream deck bindings.

  shurectl --mute          # toggle
  shurectl --mute on       # mute
  shurectl --mute off      # unmute

Composes with --device to target a specific HID path when multiple
devices are present. Toggle reads current state via get_state() before
applying; on/off skip the read entirely.