### PR TITLE
feat: read and display identity strings from device (#63, #64)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,7 +1733,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shurectl"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shurectl"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2024"
 description = "shurectl — TUI configurator for Shure USB audio interfaces and microphones"
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An open-source terminal UI configurator for Shure USB audio interfaces and micro
 - **High-Pass Filter** — Off / 75 Hz / 150 Hz
 - **Real-time Level Meter** — dBFS input meter with peak-hold display
 - **4 Preset Slots** — save and load named presets stored as TOML in `~/.config/shurectl/presets/`
-- **Device Info** — serial number
+- **Device Info** — factory serial number, device name, and firmware version
 - **Demo mode** — run without a device plugged in (`--demo`)
 
 ### MVX2U Gen 1

--- a/src/bin/probe.rs
+++ b/src/bin/probe.rs
@@ -12,7 +12,7 @@
 //!   cargo run --bin probe -- --output results.txt
 //!   cargo run --bin probe -- --page 0x03
 //!   cargo run --bin probe -- --also-mix-class          # try is_mix=0x01 for every address
-//!   cargo run --bin probe -- --also-lock-class         # try CMD_GET_LOCK for every address
+//!   cargo run --bin probe -- --also-lock-class         # CMD_GET_LOCK at prefix 0x06 and 0x00
 //!   cargo run --bin probe -- --page 0x01 --also-mix-class  # hunt for MVX2U-style mix features
 //!
 //! The tool is READ-ONLY — it only sends GET packets, never SET or CONFIRM.
@@ -24,6 +24,12 @@
 //!   0x00 — standard features (used for almost everything)
 //!   0x01 — mix features (used for MVX2U monitor mix at [0x01, 0x86])
 //!   0x06 — lock features (used for config lock at [0x00, 0xA6])
+//!
+//! The command class (CMD_GET_FEAT vs CMD_GET_LOCK) and the prefix byte are
+//! independent. Config lock uses CMD_GET_LOCK with prefix 0x06, but the identity
+//! strings — device name [0x00, 0x12], serial [0x00, 0x03], firmware [0x00, 0x09]
+//! — use CMD_GET_LOCK with the standard prefix 0x00. --also-lock-class therefore
+//! sweeps the lock command class at both 0x06 and 0x00.
 //!
 //! # MV6 monitor mix — why the probe missed it
 //!
@@ -206,7 +212,11 @@ struct Cli {
     #[arg(long)]
     page: Option<String>,
 
-    /// Also try CMD_GET_LOCK command class for every address.
+    /// Also sweep every address with the CMD_GET_LOCK command class, using both
+    /// payload prefix 0x06 (config-lock features) and prefix 0x00. The prefix 0x00
+    /// pass surfaces the identity strings — device name [0x00, 0x12], serial
+    /// [0x00, 0x03], firmware [0x00, 0x09] — which answer to the lock command
+    /// class but the standard prefix rather than 0x06.
     #[arg(long)]
     also_lock_class: bool,
 
@@ -455,12 +465,23 @@ impl Probe {
         self.sweep_page_with_prefix(page, &CMD_GET_FEAT, 0x01, "mix")
     }
 
-    /// Sweep all 256 addresses on a page using CMD_GET_LOCK command class.
+    /// Sweep all 256 addresses on a page using the CMD_GET_LOCK command class,
+    /// once with payload prefix 0x06 (config-lock features) and once with prefix
+    /// 0x00. The command class and the payload prefix are independent: config lock
+    /// at [0x00, 0xA6] answers to prefix 0x06, but the identity strings (device
+    /// name [0x00, 0x12], serial [0x00, 0x03], firmware [0x00, 0x09]) answer to
+    /// the same command class with the standard prefix 0x00. Sweeping both is
+    /// required to surface every lock-class feature.
     fn sweep_page_lock_class(&mut self, page: u8) -> Result<()> {
         self.log(&format!(
             "\n── Page 0x{page:02X} sweep (CMD_GET_LOCK class, prefix=0x06) ────────────"
         ));
-        self.sweep_page_with_prefix(page, &CMD_GET_LOCK, 0x06, "lock")
+        self.sweep_page_with_prefix(page, &CMD_GET_LOCK, 0x06, "lock")?;
+
+        self.log(&format!(
+            "\n── Page 0x{page:02X} sweep (CMD_GET_LOCK class, prefix=0x00) ────────────"
+        ));
+        self.sweep_page_with_prefix(page, &CMD_GET_LOCK, 0x00, "lock-std")
     }
 
     /// Sweep all 256 sub-addresses on a page using MV7+ 3-level addressing:

--- a/src/device.rs
+++ b/src/device.rs
@@ -40,20 +40,20 @@ use hidapi::{HidApi, HidDevice};
 use crate::protocol::{
     self, DeviceModel, DeviceState, MV6_PID, MV7_PLUS_PID, MVX2U_GEN2_PID, PACKET_SIZE, PID, VID,
     apply_response, cmd_confirm, cmd_factory_reset, cmd_get_auto_gain, cmd_get_auto_position,
-    cmd_get_auto_tone, cmd_get_compressor, cmd_get_eq_band_enable, cmd_get_eq_band_gain,
-    cmd_get_eq_enable, cmd_get_gain, cmd_get_hpf, cmd_get_limiter, cmd_get_lock, cmd_get_mix,
-    cmd_get_mode, cmd_get_mute, cmd_get_mv6_denoiser, cmd_get_mv6_gain_lock, cmd_get_mv6_mix,
-    cmd_get_mv6_mute_btn_disable, cmd_get_mv6_popper_stopper, cmd_get_mv6_tone,
-    cmd_get_mv7_led_behavior, cmd_get_mv7_led_brightness, cmd_get_mv7_led_live_edge,
-    cmd_get_mv7_led_live_interior, cmd_get_mv7_led_live_middle, cmd_get_mv7_led_live_theme,
-    cmd_get_mv7_led_pulsing_color, cmd_get_mv7_led_solid_color, cmd_get_mv7_led_solid_theme,
-    cmd_get_mv7_playback_mix, cmd_get_mv7_reverb_intensity, cmd_get_mv7_reverb_monitor,
-    cmd_get_mv7_reverb_output, cmd_get_mv7_reverb_type, cmd_get_phantom, cmd_set_lock,
-    cmd_set_mv7_gain, cmd_set_mv7_led_behavior, cmd_set_mv7_led_brightness,
-    cmd_set_mv7_led_live_edge, cmd_set_mv7_led_live_interior, cmd_set_mv7_led_live_middle,
-    cmd_set_mv7_led_live_theme, cmd_set_mv7_led_pulsing_color, cmd_set_mv7_led_pulsing_theme,
-    cmd_set_mv7_led_solid_color, cmd_set_mv7_led_solid_theme, parse_response,
-    parse_response_with_prefix,
+    cmd_get_auto_tone, cmd_get_compressor, cmd_get_device_name, cmd_get_eq_band_enable,
+    cmd_get_eq_band_gain, cmd_get_eq_enable, cmd_get_firmware_version, cmd_get_gain, cmd_get_hpf,
+    cmd_get_limiter, cmd_get_lock, cmd_get_mix, cmd_get_mode, cmd_get_mute, cmd_get_mv6_denoiser,
+    cmd_get_mv6_gain_lock, cmd_get_mv6_mix, cmd_get_mv6_mute_btn_disable,
+    cmd_get_mv6_popper_stopper, cmd_get_mv6_tone, cmd_get_mv7_led_behavior,
+    cmd_get_mv7_led_brightness, cmd_get_mv7_led_live_edge, cmd_get_mv7_led_live_interior,
+    cmd_get_mv7_led_live_middle, cmd_get_mv7_led_live_theme, cmd_get_mv7_led_pulsing_color,
+    cmd_get_mv7_led_solid_color, cmd_get_mv7_led_solid_theme, cmd_get_mv7_playback_mix,
+    cmd_get_mv7_reverb_intensity, cmd_get_mv7_reverb_monitor, cmd_get_mv7_reverb_output,
+    cmd_get_mv7_reverb_type, cmd_get_phantom, cmd_get_serial, cmd_set_lock, cmd_set_mv7_gain,
+    cmd_set_mv7_led_behavior, cmd_set_mv7_led_brightness, cmd_set_mv7_led_live_edge,
+    cmd_set_mv7_led_live_interior, cmd_set_mv7_led_live_middle, cmd_set_mv7_led_live_theme,
+    cmd_set_mv7_led_pulsing_color, cmd_set_mv7_led_pulsing_theme, cmd_set_mv7_led_solid_color,
+    cmd_set_mv7_led_solid_theme, parse_response, parse_response_with_prefix,
 };
 
 #[cfg(target_os = "linux")]
@@ -275,6 +275,9 @@ impl ShureDevice {
             cmd_get_limiter,
             cmd_get_compressor,
             cmd_get_eq_enable,
+            cmd_get_device_name,
+            cmd_get_firmware_version,
+            cmd_get_serial,
         ];
 
         self.run_getters(getters, &mut state, "get_state");
@@ -313,6 +316,9 @@ impl ShureDevice {
             cmd_get_mv6_popper_stopper,
             cmd_get_mv6_tone,
             cmd_get_mv6_gain_lock,
+            cmd_get_device_name,
+            cmd_get_firmware_version,
+            cmd_get_serial,
         ];
 
         self.run_getters(getters, &mut state, "get_state(mvx2u_gen2)");
@@ -337,6 +343,9 @@ impl ShureDevice {
             cmd_get_mv6_gain_lock,
             cmd_get_mv6_mix,
             cmd_get_mv6_mute_btn_disable,
+            cmd_get_device_name,
+            cmd_get_firmware_version,
+            cmd_get_serial,
         ];
 
         self.run_getters(getters, &mut state, "get_state(mv6)");
@@ -374,6 +383,9 @@ impl ShureDevice {
             cmd_get_mv7_led_pulsing_color,
             cmd_get_mv7_led_solid_theme,
             // Pulsing theme (A6) aliases FEAT_LOCK — not readable via GET.
+            cmd_get_device_name,
+            cmd_get_firmware_version,
+            cmd_get_serial,
         ];
         self.run_getters(getters, &mut state, "get_state(mv7plus)");
 
@@ -387,6 +399,17 @@ impl ShureDevice {
         }
 
         Ok(state)
+    }
+
+    /// Read just the factory serial number (the serial printed on the device,
+    /// shown in the MOTIV app) from an opened device. Returns `None` if the device
+    /// can't be queried or doesn't report one. Used by `--list` to upgrade the
+    /// displayed serial from the USB descriptor value to the printed serial.
+    pub fn read_factory_serial(&self) -> Option<String> {
+        let pkt = cmd_get_serial(self.next_seq());
+        let (feat, value) = self.send_get(&pkt).ok()??;
+        let mut state = DeviceState::default();
+        apply_response(feat, &value, &mut state).then_some(state.factory_serial)
     }
 
     // ── Shared SET commands ───────────────────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,11 +116,18 @@ fn main() -> Result<()> {
         } else {
             println!("Found {} Shure device(s):", devs.len());
             for d in devs {
+                // Show the factory serial (printed on the device) when we can read
+                // it; fall back to the USB descriptor serial if the device can't be
+                // opened or doesn't report one. This briefly opens each device.
+                let serial = device::ShureDevice::open_path(&d.path)
+                    .ok()
+                    .and_then(|dev| dev.read_factory_serial())
+                    .unwrap_or(d.serial);
                 println!(
                     "  {} | {} | S/N: {}",
                     d.path,
                     d.model.display_name(),
-                    d.serial
+                    serial
                 );
             }
         }

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -874,6 +874,9 @@ mod tests {
             led_live_middle_rgb: [0x1F, 0x1F, 0x1F],
             led_live_interior_rgb: [0x00, 0x00, 0x00],
             serial_number: String::from("TEST001"),
+            device_name: String::from("Unknown"),
+            firmware_version: String::from("Unknown"),
+            factory_serial: String::from("Unknown"),
         }
     }
 
@@ -1029,6 +1032,9 @@ mod tests {
             led_live_middle_rgb: [0x1F, 0x1F, 0x1F],
             led_live_interior_rgb: [0x00, 0x00, 0x00],
             serial_number: String::from("MV6TEST"),
+            device_name: String::from("Unknown"),
+            firmware_version: String::from("Unknown"),
+            factory_serial: String::from("Unknown"),
         }
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -262,6 +262,20 @@ const FEAT_AUTO_TONE: [u8; 2] = [0x01, 0x83];
 const FEAT_AUTO_GAIN: [u8; 2] = [0x01, 0x87];
 const FEAT_EQ: [u8; 2] = [0x02, 0x00];
 
+// ── Identity strings (read-only, lock class, payload prefix 0x00) ─────────────
+// These live on page 0x00 and answer to CMD_GET_LOCK with prefix 0x00 — not 0x06,
+// which is the config-lock prefix. The response value is a length-prefixed ASCII
+// string: [len_hi, len_lo, bytes…] where len is a big-endian u16 equal to the
+// whole value length. Confirmed on MVX2U Gen 2 (PID 0x1033); see issue #63.
+/// User-set device name (set in the MOTIV app, persisted on the adapter).
+const FEAT_DEVICE_NAME: [u8; 2] = [0x00, 0x12];
+/// Firmware version string, e.g. "1.2.0.6".
+const FEAT_FIRMWARE: [u8; 2] = [0x00, 0x09];
+/// Factory serial number printed on the device and shown in the MOTIV app
+/// (e.g. "3EK26001276"). Distinct from the USB descriptor serial. Confirmed at
+/// [00 02] on MVX2U Gen 2 (PID 0x1033); see issue #64.
+const FEAT_SERIAL: [u8; 2] = [0x00, 0x02];
+
 // EQ band feature addresses: [enable_addr, gain_addr]
 // Bands are fixed at 100, 250, 1000, 4000, 10000 Hz.
 const EQ_BAND_ADDRS: [([u8; 2], [u8; 2]); 5] = [
@@ -446,6 +460,17 @@ pub struct DeviceState {
 
     /// Device serial number string, populated after connection.
     pub serial_number: String,
+    /// User-set device name read from the adapter (lock-class feature 0x0012).
+    /// "Unknown" if the device does not report it.
+    pub device_name: String,
+    /// Firmware version string read from the adapter (lock-class feature 0x0009),
+    /// e.g. "1.2.0.6". "Unknown" if the device does not report it.
+    pub firmware_version: String,
+    /// Factory serial number read from the adapter (lock-class feature 0x0002),
+    /// e.g. "3EK26001276" — the serial printed on the device and shown in the
+    /// MOTIV app. "Unknown" if the device does not report it; callers fall back
+    /// to `serial_number` (the USB descriptor serial) in that case.
+    pub factory_serial: String,
 }
 
 impl Default for DeviceState {
@@ -490,6 +515,22 @@ impl Default for DeviceState {
             led_live_middle_rgb: [0x1F, 0x1F, 0x1F],
             led_live_interior_rgb: [0x00, 0x00, 0x00],
             serial_number: String::from("Unknown"),
+            device_name: String::from("Unknown"),
+            firmware_version: String::from("Unknown"),
+            factory_serial: String::from("Unknown"),
+        }
+    }
+}
+
+impl DeviceState {
+    /// The serial number to show the user: the factory serial (printed on the
+    /// device, shown in the MOTIV app) when the device reported one, otherwise the
+    /// USB descriptor serial as a fallback so the field is never blank.
+    pub fn display_serial(&self) -> &str {
+        if self.factory_serial != "Unknown" {
+            &self.factory_serial
+        } else {
+            &self.serial_number
         }
     }
 }
@@ -1440,6 +1481,30 @@ pub fn cmd_get_lock(seq: u8) -> Vec<u8> {
     build_packet(seq, &CMD_GET_LOCK, &payload)
 }
 
+/// Build a GET packet for the user-set device name.
+/// Lock command class with payload prefix 0x00 (the identity strings answer to
+/// the lock class but the standard prefix, not the config-lock prefix 0x06).
+/// The response is a length-prefixed ASCII string; see `decode_lp_string`.
+pub fn cmd_get_device_name(seq: u8) -> Vec<u8> {
+    let payload = [0x00, FEAT_DEVICE_NAME[0], FEAT_DEVICE_NAME[1]];
+    build_packet(seq, &CMD_GET_LOCK, &payload)
+}
+
+/// Build a GET packet for the firmware version string (e.g. "1.2.0.6").
+/// Same framing as `cmd_get_device_name`: lock class, payload prefix 0x00.
+pub fn cmd_get_firmware_version(seq: u8) -> Vec<u8> {
+    let payload = [0x00, FEAT_FIRMWARE[0], FEAT_FIRMWARE[1]];
+    build_packet(seq, &CMD_GET_LOCK, &payload)
+}
+
+/// Build a GET packet for the factory serial number (printed on the device,
+/// shown in the MOTIV app). Same framing as the other identity strings: lock
+/// class, payload prefix 0x00, length-prefixed ASCII response.
+pub fn cmd_get_serial(seq: u8) -> Vec<u8> {
+    let payload = [0x00, FEAT_SERIAL[0], FEAT_SERIAL[1]];
+    build_packet(seq, &CMD_GET_LOCK, &payload)
+}
+
 /// Build a SET packet for the config-lock feature.
 /// `locked = true` locks the device; `false` unlocks it.
 pub fn cmd_set_lock(seq: u8, locked: bool) -> Vec<u8> {
@@ -1755,6 +1820,33 @@ pub fn cmd_set_mv7_gain(seq: u8, gain_db: u8) -> Vec<u8> {
 }
 
 // ── Response decoder ──────────────────────────────────────────────────────────
+/// Decode a length-prefixed ASCII string as returned by the lock-class identity
+/// features (device name, firmware). The value is `[len_hi, len_lo, bytes…]` where
+/// `len` is a big-endian u16 equal to the full value length.
+///
+/// Returns `None` if the value is too short to hold the 2-byte length plus at
+/// least one payload byte, or if the declared length does not match the actual
+/// length. The length check rejects binary or non-string features that may answer
+/// at the same address on models we have not verified, and rejecting an empty
+/// payload means a device that reports a blank string is treated the same as one
+/// that reports nothing — both leave the field "Unknown" and hidden, rather than
+/// rendering an empty row.
+fn decode_lp_string(value: &[u8]) -> Option<String> {
+    // 2-byte length prefix + at least one payload byte.
+    if value.len() < 3 {
+        return None;
+    }
+    let declared = usize::from(u16::from_be_bytes([value[0], value[1]]));
+    if declared != value.len() {
+        return None;
+    }
+    Some(
+        String::from_utf8_lossy(&value[2..])
+            .trim_end_matches('\0')
+            .to_string(),
+    )
+}
+
 /// Apply a parsed feature response `(feat_addr, value_bytes)` to `state`.
 ///
 /// Returns `true` if the feature was recognised and applied, `false` if the
@@ -2002,6 +2094,27 @@ pub fn apply_response(feat_addr: [u8; 2], value: &[u8], state: &mut DeviceState)
             state.led_live_interior_rgb = [value[1], value[2], value[3]];
             true
         }
+        f if f == FEAT_DEVICE_NAME => match decode_lp_string(value) {
+            Some(name) => {
+                state.device_name = name;
+                true
+            }
+            None => false,
+        },
+        f if f == FEAT_FIRMWARE => match decode_lp_string(value) {
+            Some(version) => {
+                state.firmware_version = version;
+                true
+            }
+            None => false,
+        },
+        f if f == FEAT_SERIAL => match decode_lp_string(value) {
+            Some(serial) => {
+                state.factory_serial = serial;
+                true
+            }
+            None => false,
+        },
         _ => {
             // Check EQ band addresses
             for (i, (en_addr, gain_addr)) in EQ_BAND_ADDRS.iter().enumerate() {
@@ -2729,6 +2842,120 @@ mod tests {
         let applied = apply_response([0xFF, 0xFF], &[0x01], &mut state);
         assert!(!applied, "unknown feature must return false");
         assert_eq!(state.gain_db, original_gain, "state must not be mutated");
+    }
+
+    #[test]
+    fn apply_response_device_name() {
+        let mut state = DeviceState::default();
+        // [len_hi, len_lo] = 0x0013 (19 bytes total), then "MONKS MVX2U GEN 2".
+        let value = [
+            0x00, 0x13, b'M', b'O', b'N', b'K', b'S', b' ', b'M', b'V', b'X', b'2', b'U', b' ',
+            b'G', b'E', b'N', b' ', b'2',
+        ];
+        assert!(apply_response(FEAT_DEVICE_NAME, &value, &mut state));
+        assert_eq!(state.device_name, "MONKS MVX2U GEN 2");
+    }
+
+    #[test]
+    fn apply_response_firmware_version() {
+        let mut state = DeviceState::default();
+        // [len_hi, len_lo] = 0x0009 (9 bytes total), then "1.2.0.6".
+        let value = [0x00, 0x09, b'1', b'.', b'2', b'.', b'0', b'.', b'6'];
+        assert!(apply_response(FEAT_FIRMWARE, &value, &mut state));
+        assert_eq!(state.firmware_version, "1.2.0.6");
+    }
+
+    #[test]
+    fn apply_response_device_name_empty_returns_false() {
+        let mut state = DeviceState::default();
+        assert!(!apply_response(FEAT_DEVICE_NAME, &[], &mut state));
+        assert_eq!(state.device_name, "Unknown", "state must not be mutated");
+    }
+
+    #[test]
+    fn decode_lp_string_trims_trailing_nul() {
+        // Timer-style responses carry a trailing NUL counted inside the length.
+        let value = [0x00, 0x05, b'A', b'B', 0x00];
+        assert_eq!(decode_lp_string(&value).as_deref(), Some("AB"));
+    }
+
+    #[test]
+    fn decode_lp_string_rejects_length_mismatch() {
+        // A binary feature (e.g. the firmware tuple at [00 04]) is not a valid
+        // string: the declared length 0x0001 does not equal the value length.
+        let value = [0x00, 0x01, 0x00, 0x02, 0x00, 0x00, 0x00, 0x0a];
+        assert_eq!(decode_lp_string(&value), None);
+    }
+
+    #[test]
+    fn decode_lp_string_rejects_short() {
+        assert_eq!(decode_lp_string(&[0x00]), None);
+        assert_eq!(decode_lp_string(&[]), None);
+    }
+
+    #[test]
+    fn decode_lp_string_rejects_empty_payload() {
+        // A well-formed header declaring length 2 carries no payload bytes; treat
+        // it as "not reported" so the field stays "Unknown" and the row is hidden.
+        assert_eq!(decode_lp_string(&[0x00, 0x02]), None);
+    }
+
+    #[test]
+    fn display_serial_prefers_factory() {
+        let state = DeviceState {
+            factory_serial: String::from("3EK26001276"),
+            serial_number: String::from("MVX2U GEN 2#2-abcd"),
+            ..Default::default()
+        };
+        assert_eq!(state.display_serial(), "3EK26001276");
+    }
+
+    #[test]
+    fn display_serial_falls_back_to_descriptor() {
+        // factory_serial stays "Unknown" via Default.
+        let state = DeviceState {
+            serial_number: String::from("MVX2U GEN 2#2-abcd"),
+            ..Default::default()
+        };
+        assert_eq!(state.display_serial(), "MVX2U GEN 2#2-abcd");
+    }
+
+    #[test]
+    fn device_name_get_packet_uses_lock_class_prefix_zero() {
+        let pkt = cmd_get_device_name(0);
+        assert_eq!(pkt.len(), PACKET_SIZE);
+        assert_eq!(&pkt[10..13], &CMD_GET_LOCK, "must use CMD_GET_LOCK");
+        assert_eq!(pkt[13], 0x00, "identity payload prefix must be 0x00");
+        assert_eq!(&pkt[14..16], &FEAT_DEVICE_NAME);
+    }
+
+    #[test]
+    fn firmware_get_packet_uses_lock_class_prefix_zero() {
+        let pkt = cmd_get_firmware_version(0);
+        assert_eq!(pkt.len(), PACKET_SIZE);
+        assert_eq!(&pkt[10..13], &CMD_GET_LOCK, "must use CMD_GET_LOCK");
+        assert_eq!(pkt[13], 0x00, "identity payload prefix must be 0x00");
+        assert_eq!(&pkt[14..16], &FEAT_FIRMWARE);
+    }
+
+    #[test]
+    fn apply_response_factory_serial() {
+        let mut state = DeviceState::default();
+        // [len_hi, len_lo] = 0x000d (13 bytes total), then "3EK26001276".
+        let value = [
+            0x00, 0x0d, b'3', b'E', b'K', b'2', b'6', b'0', b'0', b'1', b'2', b'7', b'6',
+        ];
+        assert!(apply_response(FEAT_SERIAL, &value, &mut state));
+        assert_eq!(state.factory_serial, "3EK26001276");
+    }
+
+    #[test]
+    fn serial_get_packet_uses_lock_class_prefix_zero() {
+        let pkt = cmd_get_serial(0);
+        assert_eq!(pkt.len(), PACKET_SIZE);
+        assert_eq!(&pkt[10..13], &CMD_GET_LOCK, "must use CMD_GET_LOCK");
+        assert_eq!(pkt[13], 0x00, "identity payload prefix must be 0x00");
+        assert_eq!(&pkt[14..16], &FEAT_SERIAL);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -97,6 +97,13 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
         )
     };
 
+    // Identity label: the user-set device name when present, otherwise the model.
+    let device_label: &str = if app.device_state.device_name != "Unknown" {
+        &app.device_state.device_name
+    } else {
+        app.device_model.display_name()
+    };
+
     let title = vec![
         Span::styled(
             "shurectl",
@@ -104,8 +111,9 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::raw("  "),
         demo_tag,
+        Span::styled(format!("  {device_label}"), Style::default().fg(C_TEXT)),
         Span::styled(
-            format!("  S/N: {}", app.device_state.serial_number),
+            format!("  S/N: {}", app.device_state.display_serial()),
             Style::default().fg(C_DIM),
         ),
     ];
@@ -3619,10 +3627,33 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
             Span::styled("  Model        : ", Style::default().fg(C_DIM)),
             Span::styled(model.display_name(), Style::default().fg(C_TEXT)),
         ]),
-        Line::from(vec![
-            Span::styled("  Serial No.   : ", Style::default().fg(C_DIM)),
-            Span::styled(&*ds.serial_number, Style::default().fg(C_TEXT)),
-        ]),
+    ];
+
+    // Device name (user-set) sits under Model so the panel reads "what it is and
+    // what you call it", then the device-reported identifiers below. Name and
+    // firmware are read over HID from the lock-class identity features; each is
+    // shown only when the device reported it (otherwise the field stays "Unknown"
+    // and the row is hidden), so we never display an empty field.
+    if ds.device_name != "Unknown" {
+        lines.push(Line::from(vec![
+            Span::styled("  Device Name  : ", Style::default().fg(C_DIM)),
+            Span::styled(&*ds.device_name, Style::default().fg(C_TEXT)),
+        ]));
+    }
+
+    lines.push(Line::from(vec![
+        Span::styled("  Serial No.   : ", Style::default().fg(C_DIM)),
+        Span::styled(ds.display_serial(), Style::default().fg(C_TEXT)),
+    ]));
+
+    if ds.firmware_version != "Unknown" {
+        lines.push(Line::from(vec![
+            Span::styled("  Firmware     : ", Style::default().fg(C_DIM)),
+            Span::styled(&*ds.firmware_version, Style::default().fg(C_TEXT)),
+        ]));
+    }
+
+    lines.extend([
         Line::from(vec![
             Span::styled("  USB VID/PID  : ", Style::default().fg(C_DIM)),
             Span::styled(vid_pid, Style::default().fg(C_TEXT)),
@@ -3641,7 +3672,7 @@ fn draw_info_tab(f: &mut Frame, app: &App, area: Rect) {
             Span::styled("  Presets      : ", Style::default().fg(C_DIM)),
             Span::styled("4 slots (host-side TOML)", Style::default().fg(C_TEXT)),
         ]),
-    ];
+    ]);
 
     let cap_rows: &[(&str, &str)] = match model {
         DeviceModel::Mvx2u => &[


### PR DESCRIPTION
Add infrastructure to read lock-class identity strings (CMD_GET_LOCK, payload prefix 0x00, length-prefixed ASCII) from all four supported models. These features were discovered via the updated probe tool and confirmed on MVX2U Gen 2.

Protocol
- Add decode_lp_string() helper: validates the self-describing length prefix, rejects empty payloads, trims trailing NULs, and rejects length mismatches so binary features at unverified addresses fall back to "Unknown" rather than displaying garbage
- Add FEAT_DEVICE_NAME [00 12], FEAT_FIRMWARE [00 09], FEAT_SERIAL [00 02] constants with constructors cmd_get_device_name(), cmd_get_firmware_version(), cmd_get_serial()
- Add device_name, firmware_version, factory_serial fields to DeviceState (default "Unknown"); add display_serial() method that prefers the factory serial and falls back to the USB descriptor serial
- Wire all three getters into every model's get_state_*() slice

probe
- --also-lock-class now sweeps CMD_GET_LOCK at both prefix 0x06 (config-lock features) and prefix 0x00 (identity strings); previously only 0x06 was swept, making the identity block invisible

UI
- Info tab: show Device Name (below Model), Serial No. (factory serial preferred), and Firmware when reported; rows hidden when "Unknown" so no model regresses to empty fields
- Banner: show user-set device name when present, otherwise model name, followed by factory serial
- --list: open each device to read the factory serial; falls back to USB descriptor serial if the device can't be opened or doesn't report