### PR TITLE
docs: rewrite CLAUDE.md for conciseness and current agent conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ See `Cargo.toml` for versions. Usage notes that matter:
 - Exhaustive match arms — avoid wildcard `_` that silently swallows variants
 - Meaningful names (`gain_db` not `g`); delete replaced code, no versioned function names
 - Validate packet arguments before encoding (clamp, don't panic)
-- Never write firmware-update packets — those byte sequences are intentionally omitted (see README legal section)
+- Never write firmware-update packets — those byte sequences are intentionally omitted (see readme legal section)
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,368 +1,143 @@
-# shurectl — Project Instructions
+# shurectl
 
-The goal of this project is to build and maintain **shurectl**, an open-source terminal UI
-configurator for Shure USB audio interfaces (MVX2U Gen 1/Gen 2, MV6, and MV7+) on Linux
-and macOS. It replaces the Windows/Mac-only ShurePlus MOTIV Desktop app by communicating
-with devices directly over USB HID.
+Terminal UI configurator for Shure USB audio interfaces (MVX2U, MV6) on Linux and macOS.
+Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app by talking to the device directly
+over USB HID. Single-crate Rust binary. Prefer the simple, obvious solution over clever
+abstractions.
 
-This is a Rust project. Operate as a senior Rust developer: write clean, readable, maintainable
-code. Avoid clever abstractions. The simple, obvious solution is almost always correct.
+## Verification
 
----
+Before considering any change complete:
 
-## 🚨 AUTOMATED CHECKS ARE MANDATORY
-
-ALL check failures are BLOCKING — everything must be ✅ GREEN before moving on.
-No errors. No formatting issues. No linting problems. Zero tolerance.
-
-**Reality checkpoint command:**
 ```
 cargo clippy -- -D warnings && cargo fmt --check && cargo test
 ```
 
-Run this after every complete feature, before starting a new component, and whenever
-something feels wrong.
+For non-trivial features, explore the relevant code and confirm a plan before implementing.
 
----
-
-## CRITICAL WORKFLOW — ALWAYS FOLLOW THIS
-
-**Research → Plan → Implement**
-
-Never jump straight to coding. Always follow this sequence:
-
-1. **Research**: Explore the codebase, understand existing patterns
-2. **Plan**: Create a detailed implementation plan and confirm it with me
-3. **Implement**: Execute with validation checkpoints
-
-When asked to implement any feature, first say:
-> "Let me research the codebase and create a plan before implementing."
-
-For complex or architectural decisions, say:
-> "Let me ultrathink about this before proposing a solution."
-
----
-
-## Project Structure
-
-This is a single-crate Rust binary. All source lives under `src/`:
+## Architecture
 
 ```
 src/
-  main.rs       # Entry point, CLI args (--demo, --list), event loop, key handling
-  app.rs        # Application state: Tab, Focus, DeviceState, DeviceAction events
-  device.rs     # hidapi wrapper: open ShureDevice, send/receive HID reports, model dispatch
-  meter.rs      # cpal audio capture: real-time dBFS metering, RollingWindow, PeakWindow
-  presets.rs    # Host-side preset storage: TOML serialisation, load/save/delete, PresetSlot
-  protocol.rs   # Packet encoding, CRC-16/ANSI, all command constructors, apply_response()
-  ui.rs         # ratatui rendering: all 5 tabs + help overlay
+  main.rs       # Entry point, CLI args (--demo, --list, --mute), event loop, apply_action()
+  app.rs        # App state: Tab, Focus, DeviceState, DeviceAction events
+  device.rs     # hidapi wrapper: open device, send/receive HID reports
+  meter.rs      # cpal capture: dBFS metering, RollingWindow, PeakWindow
+  presets.rs    # Host-side presets: TOML load/save/delete, PresetSlot
+  protocol.rs   # Packet encoding, CRC-16/ANSI, command constructors, apply_response()
+  ui.rs         # ratatui rendering: 5 tabs (Main | EQ | Dynamics | Presets | Info) + help overlay
 ```
 
-**Data flow:** key event → `handle_key()` → `DeviceAction` → `apply_action()` → `device.rs` → HID packet → `protocol.rs`
+**Control flow:** key event → `handle_key()` → `DeviceAction` → `apply_action()` (main.rs) → `device.rs` → `protocol.rs` packet.
 
-**Meter data flow:** cpal audio callback → `meter_level` (AtomicI32) + `peak_window` (Mutex<PeakWindow>) → `ui.rs` reads on each render tick
+**Meter flow:** cpal callback → `meter_level` (AtomicI32) + `peak_window` (Mutex) → read by `ui.rs` each render tick.
 
-**Tab structure:** Main | EQ | Dynamics | Presets | Info
+**Layering rules (strict):**
+- `apply_action()` in `main.rs` is the *only* place that writes to the device. Never call `device.rs` from `ui.rs` or `app.rs`.
+- Raw protocol byte values live *only* in `protocol.rs` as named constants. Never hardcode bytes elsewhere.
 
----
+## USB HID Protocol
 
-## shurectl Domain Rules
-
-These are project-specific patterns learned from working in this codebase.
-
-### Supported Devices
-
-| Model | VID | PID |
-|---|---|---|
-| MVX2U Gen 1 | `0x14ED` | `0x1013` |
-| MVX2U Gen 2 | `0x14ED` | `0x1033` |
-| MV6 | `0x14ED` | `0x1026` |
-| MV7+ | `0x14ED` | `0x1019` |
-
-All four share the same packet framing and CRC algorithm. Feature addresses and value
-encodings differ per model. The `DeviceModel` enum in `protocol.rs` drives all
-model-specific dispatch — gain ranges, UI tab availability, and protocol variants.
-
-### USB HID Protocol
-
-All devices use plain USB HID Output/Input Reports for configuration. Every packet is
-exactly 64 bytes, sent via `hid_write()` and received via `hid_read()`:
+Every packet is exactly 64 bytes (65 with hidapi's report-ID byte 0), sent via `hid_write()`
+/ `hid_read()` on `/dev/hidrawN` — not the USB audio class interface, and not
+`HIDIOCSFEATURE`/`HIDIOCGFEATURE`.
 
 ```
-[0x01] [0x11] [0x22] [seq] [0x03] [0x08] [data_len] [0x70] [data_len] [cmd0][cmd1][cmd2] [feat_addr...] [value...] [crc_hi] [crc_lo] [0x00 padding...]
-  ↑─── Report ID ───↑                                                                      ↑──────────── CRC-16/ANSI covers from 0x11 onward ───────────────↑
+[0x01] [0x11] [0x22] [seq] [0x03] [0x08] [len] [0x70] [len] [cmd0..cmd2] [feat_addr..] [value..] [crc_hi] [crc_lo] [pad..]
+  ^report ID    ^magic, never changes            CRC-16/ANSI covers 0x11 onward
 ```
 
-- **Header magic**: `0x11 0x22` — never changes
-- **Report ID**: `0x01` — required as byte 0 by hidapi's `hid_write()`; our buffers are 65 bytes total (1 report ID + 64 payload)
-- **CRC**: CRC-16/ANSI — poly `0x8005`, init `0x0000`, reflected input and output (NOT CCITT-FALSE)
-- **Transport**: plain HID Output Reports (`hid_write`) for commands; Input Reports (`hid_read`) for responses — `HIDIOCSFEATURE`/`HIDIOCGFEATURE` are NOT used
-- **Interface**: accessed via `/dev/hidrawN`, not the USB audio class interface
-- **SET + CONFIRM**: every SET command must be immediately followed by a CONFIRM packet (`CMD_CONFIRM`); the device will not apply the change without it
+- **USB IDs:** VID `0x14ED`, PID `0x1013`
+- **CRC:** CRC-16/ANSI — poly `0x8005`, init `0x0000`, reflected in/out (NOT CCITT-FALSE)
+- **SET + CONFIRM:** every SET must be immediately followed by a `CMD_CONFIRM` packet or the device won't apply the change
+- **State readback:** no monolithic GET_STATE. `device.rs::get_state()` issues individual `cmd_get_*` packets; `apply_response()` dispatches on the 2-byte feature address and writes into `DeviceState`. Feature address → field mapping is documented inline in `protocol.rs`.
 
-All command byte values and feature address constants live in `protocol.rs`.
-Do not hardcode raw byte values outside of `protocol.rs`.
+**When a command misbehaves on real hardware, capture packets before guessing:**
 
-### MV7+ Protocol Quirks
-
-The MV7+ has two behaviours that differ from all other models:
-
-**Double unsolicited IN response after CONFIRM.** After every SET + CONFIRM pair, the MV7+
-sends two unsolicited Input Reports before going quiet:
-1. A CONFIRM ACK (`cmd=[09 00 00]`)
-2. A SET echo (`RES_SET_FEAT` or `RES_SET_LOCK`) reflecting the applied value
-
-`device.rs::send_set()` drains both reads (50 ms timeout each) for MV7+ after sending the
-CONFIRM. If this drain is skipped, subsequent GET reads in `get_state()` will consume these
-stale responses instead of the actual GET replies, silently corrupting state readback.
-
-**Playback mix shares a feature address with mic mix.** The MV7+ exposes two independent mix
-controls (mic monitor and playback) at the same feature address (`FEAT_MIX`), distinguished
-by a prefix byte in the response. `send_get_with_prefix()` and `parse_response_with_prefix()`
-exist specifically for this case — they return `(prefix, feat_addr, value)` instead of
-`(feat_addr, value)`. Use this path only for `cmd_get_mv7_playback_mix`; all other GET
-commands use the standard `send_get()`.
-
-### Adding a New Command
-
-New device commands always follow this sequence — do not skip steps:
-
-1. `protocol.rs` — add `FEAT_*` address constant, `cmd_get_*` and `cmd_set_*` constructor functions, and a matching branch in `apply_response()` to decode the GET response into `DeviceState`
-2. `device.rs` — add typed `get_*` / `set_*` methods on `ShureDevice` that call the constructors; add `cmd_get_*` to the appropriate `get_state_*()` getter slice if it's part of full state readback
-3. `app.rs` — add a `DeviceAction` variant if user-triggerable; update `adjust_focused()` or `toggle_focused()` as appropriate
-4. `main.rs` — handle the new variant in `apply_action()`
-5. `ui.rs` — add UI element if needed
-6. `protocol.rs` tests — add a roundtrip test for the new packet
-
-### Protocol Verification
-
-If a command doesn't behave as expected on the real device, **capture packets first**:
-
-```bash
+```
 sudo modprobe usbmon
-lsusb | grep -i shure          # find bus number
-sudo wireshark -i usbmonN      # replace N with bus number
-# Filter: usb.transfer_type == 0x01
+lsusb | grep -i shure            # find bus number
+sudo wireshark -i usbmonN        # filter: usb.transfer_type == 0x01
 ```
 
-Compare the captured bytes to what the `cmd_*` constructors in `protocol.rs` produce.
-Feature address constants (`FEAT_*`) and value encoding are the most likely source of
-firmware-version differences. Fix these in `protocol.rs` only — never in `device.rs` or
-higher layers.
+Compare captures against `cmd_*` constructor output. Firmware-version differences almost
+always show up as `FEAT_*` addresses or value encoding — fix in `protocol.rs` only. If a
+byte offset or command value is uncertain, say so and propose verifying with usbmon rather
+than assuming.
 
-### State Readback
+## Adding a New Command
 
-State is fetched by issuing individual `cmd_get_*` packets for each feature, not by a single
-monolithic GET_STATE command. `device.rs::get_state()` dispatches to a model-specific
-`get_state_*()` method (`get_state_mvx2u`, `get_state_mvx2u_gen2`, `get_state_mv6`,
-`get_state_mv7_plus`), each of which calls its own getter slice and feeds every response
-into `apply_response()`.
+Follow this sequence, no skipped steps:
 
-`apply_response()` dispatches on the 2-byte feature address returned by the device and
-writes the decoded value into the appropriate field of `DeviceState`.
+1. `protocol.rs` — `FEAT_*` constant, `cmd_get_*`/`cmd_set_*` constructors, `apply_response()` branch decoding into `DeviceState`
+2. `device.rs` — typed `get_*`/`set_*` methods on `Mvx2u`; add getter to the `getters` slice in `get_state()` if part of full readback
+3. `app.rs` — `DeviceAction` variant if user-triggerable; wire into `adjust_focused()` or `toggle_focused()`
+4. `main.rs` — handle the variant in `apply_action()`
+5. `ui.rs` — UI element if needed
+6. `protocol.rs` — roundtrip test for the new packet
+7. `README.md` — update protocol table and keyboard shortcuts
 
-Feature address → `DeviceState` field mapping is documented inline in `protocol.rs`.
-If live device state looks wrong after `get_state()`, check the feature address constants
-(`FEAT_*`) and the value-decoding branches in `apply_response()`.
+## TUI / Focus Model
 
-### TUI / Focus Model
+- `Tab` selects the visible panel; `Focus` selects the active control within it
+- `adjust_focused()` handles ←/→ for sliders; `toggle_focused()` handles Enter/Space for booleans and enum cycling
+- Both return `Option<DeviceAction>` — `None` means UI-only change, no HID write
+- Preset name editing lives in `main.rs::handle_key()` (not `toggle_focused()`): when `editing_preset_name` is true, chars append, Enter commits (`PersistPresetName`), Esc cancels
 
-- `Tab` enum controls which panel is visible
-- `Focus` enum controls which control within a tab is active
-- `App::adjust_focused()` handles `←→` for sliders/numeric controls
-- `App::toggle_focused()` handles `Enter/Space` for booleans and cycling enums
-- Both return `Option<DeviceAction>` — `None` means UI-only change, no HID write needed
-- `apply_action()` in `main.rs` is the only place that writes to the device
+## Meter
 
-Never call `device.rs` methods from `ui.rs` or `app.rs`. All device writes go through
-`apply_action()`.
-
-### Meter Architecture
-
-`meter.rs` runs a cpal audio capture stream on a background thread. It publishes two values
-into `App`, shared via `Arc`:
-
+`meter.rs` runs a cpal capture stream on a background thread, publishing via `Arc`:
 - `meter_level: Arc<AtomicI32>` — instantaneous peak dBFS × 10, lock-free
-- `peak_window: Arc<Mutex<PeakWindow>>` — two `RollingWindow`s: `short` (0.3 s) drives the
-  bar height; `long` (3.0 s) drives the peak-hold marker
+- `peak_window: Arc<Mutex<PeakWindow>>` — `short` (0.3 s) window drives bar height; `long` (3.0 s) drives peak-hold marker
 
-`start_meter()` returns a `MeterStatus` enum. The caller must keep the `Stream` inside
-`MeterStatus::Running` alive — dropping it stops capture. The meter is not started in demo mode.
+`start_meter()` returns `MeterStatus`; the caller must keep the `Stream` in
+`MeterStatus::Running` alive — dropping it stops capture. The meter does not start in demo mode.
 
-### Preset Storage
+## Presets
 
-`presets.rs` implements host-side preset management. Presets are stored as TOML files in
-`~/.config/shurectl/presets/`, with 4 fixed slots named `preset_1.toml`–`preset_4.toml`.
+TOML files in `~/.config/shurectl/presets/`, 4 fixed slots (`preset_1.toml`–`preset_4.toml`).
 
-Key design decisions:
-- **Mirror types**: `presets.rs` defines separate `Ser*` enums (`SerInputMode`, `SerMicPosition`,
-  etc.) with `#[derive(Serialize, Deserialize)]`. Protocol types in `protocol.rs` stay free of
-  serde concerns. Stable on-disk format is decoupled from internal enum evolution.
-- **`PresetSlot`**: captures all configurable DSP settings from `DeviceState` — every field
-  that can be sent to the device over HID. Hardware-identity fields (`serial_number`,
-  `firmware_version`) are intentionally excluded.
-- **`PresetSlot::from_device_state()`** — snapshot live state into a slot.
-- **`PresetSlot::apply_to_device_state()`** — restore a slot onto `DeviceState`, preserving identity fields.
-- **`load_all_presets()`** — loads all 4 slots at startup; missing files produce `None` entries.
-- **`dirs_next::config_dir()`** — resolves `~/.config/` on Linux; falls back to `$HOME/.config/`
-  if `dirs-next` returns `None`.
+- **Mirror types:** `presets.rs` defines `Ser*` enums with serde derives so `protocol.rs` types stay serde-free — on-disk format is decoupled from internal enum evolution
+- `PresetSlot` captures all DSP settings from `DeviceState`; identity fields (`serial_number`, `firmware_version`) are excluded and preserved on apply
+- `load_all_presets()` runs at startup; missing files → `None`
+- `DeviceAction` variants: `SavePreset`, `LoadPreset` (applies then sends all SETs), `DeletePreset`, `PersistPresetName`
 
-`DeviceAction` preset variants (handled in `main.rs::apply_action()`):
-- `SavePreset(usize)` — snapshot current state, write TOML, update `app.presets[i]`
-- `LoadPreset(usize)` — call `apply_to_device_state()`, send all SET commands to device
-- `DeletePreset(usize)` — remove the TOML file, set `app.presets[i] = None`
-- `PersistPresetName(usize)` — write the already-in-memory-updated name back to disk
+## Demo Mode
 
-Preset name editing is handled in `main.rs::handle_key()`, not in `toggle_focused()`.
-When `app.editing_preset_name` is `true`, character keys append to the name and `Enter`
-commits (fires `PersistPresetName`), while `Esc` cancels without saving.
+`--demo` runs with `device: None`; `send_if_connected()` silently succeeds. All app state
+changes still apply — only HID writes are skipped. Demo mode must always remain fully navigable.
 
-### Demo Mode
+## Crates
 
-`--demo` runs with `device: None`. `send_if_connected()` silently succeeds when
-`device` is `None`. All app state changes still apply — only HID writes are skipped.
-This is intentional: demo mode should always be fully navigable.
+See `Cargo.toml` for versions. Usage notes that matter:
 
-### Key Crates in Use
+- `ratatui` — use `Frame::render_widget()`, not direct buffer writes
+- `crossterm` — handle `KeyEventKind::Press` only
+- `hidapi` — `linux-native` feature, `/dev/hidrawN` access
+- `cpal` — default input device only
+- `libc` — stderr suppression (`dup`/`dup2`) during cpal ALSA/JACK probing
+- `anyhow` — all fallible functions return `anyhow::Result<T>`
+- `tempfile` (dev) — hermetic temp dirs in `presets.rs` tests
 
-- `ratatui 0.30` — TUI rendering; use `Frame::render_widget()`, not direct buffer writes
-- `crossterm 0.29` — terminal backend and key events; `KeyEventKind::Press` only
-- `hidapi 2.4` — HID device open/read/write. Per-OS features: `linux-native` (`/dev/hidrawN`), `macos-shared-device` (IOKit), and default Windows backend (`\\.\HID#VID_...`)
-- `cpal 0.17` — audio capture for the input level meter; default input device only
-- `libc 0.2` (Unix only) — stderr suppression during cpal ALSA/JACK probing (`dup`/`dup2`)
-- `anyhow` — all fallible functions return `anyhow::Result`
-- `clap 4.5` — CLI argument parsing; `derive` feature only
-- `serde 1` (with `derive` feature) — serialisation traits for preset TOML files
-- `toml 0.8` — TOML serialisation/deserialisation for preset files
-- `dirs-next 2.0` — platform config directory resolution (`~/.config/` on Linux)
-- `tempfile 3` (dev-dependency) — hermetic temp directories in `presets.rs` tests
+## Rust Rules
 
----
+- No `unwrap()`/`expect()` in production paths; no `panic!()` outside tests; no `todo!()`/`unimplemented!()` in final code
+- No `println!()` — `eprintln!()` only at startup; use the TUI status bar otherwise
+- Prefer borrowing; justify every `.clone()`
+- Exhaustive match arms — avoid wildcard `_` that silently swallows variants
+- Meaningful names (`gain_db` not `g`); delete replaced code, no versioned function names
+- Validate packet arguments before encoding (clamp, don't panic)
+- Never write firmware-update packets — those byte sequences are intentionally omitted (see README legal section)
 
-## Rust-Specific Rules
-
-### FORBIDDEN — never do these:
-- No `unwrap()` or `expect()` in production paths — use `?` and `anyhow::Result`
-- No `panic!()` outside of tests
-- No `println!()` — errors go to `eprintln!()` only at startup; TUI status bar otherwise
-- No unnecessary `clone()` — prefer borrowing; justify every `.clone()`
-- No `todo!()` or `unimplemented!()` in final code
-- No versioned function names (`send_v2`, `build_packet_new`)
-- No keeping old and new code side-by-side — delete replaced code
-- No raw byte literals outside `protocol.rs` — use the named constants
-
-### Required standards:
-- Return `anyhow::Result<T>` from all fallible functions
-- Use `?` for early error propagation — avoid deep nesting
-- Match arms must be exhaustive; avoid wildcard `_` that silently swallows variants
-- Meaningful names: `gain_db` not `g`, `band_index` not `i`
-- Table-driven tests using `vec![(input, expected)]`
-- All protocol constants documented with inline comments explaining their purpose
-
----
-
-## Testing Strategy
+## Testing
 
 | Situation | Approach |
-|---|---|
-| New protocol command | Write roundtrip test in `protocol.rs` `#[cfg(test)]` first |
-| Packet encoding changes | Test CRC correctness and packet length invariants |
+| --- | --- |
+| New protocol command | Roundtrip test in `protocol.rs` first |
+| Packet encoding changes | Test CRC correctness and 64-byte length invariant |
 | State decode changes | Test `apply_response()` with hand-crafted response buffers |
 | Focus/navigation changes | Manual test in `--demo` mode |
-| `main()` and CLI args | Skip tests |
+| `main()` / CLI args | No tests |
 
-Performance is not a concern for this application — it is input-event-driven at ~100ms
-tick rate. Do not add benchmarks unless a specific bottleneck is identified.
-
----
-
-## Implementation Checklist
-
-A feature is complete when:
-- [ ] `cargo clippy -- -D warnings` passes clean
-- [ ] `cargo fmt --check` passes
-- [ ] `cargo test` passes (all suites)
-- [ ] New commands are documented in `README.md` (protocol table and keyboard shortcuts)
-- [ ] No dead code or unused imports remain
-- [ ] Old code that was replaced has been deleted
-- [ ] Tested in `--demo` mode for UI-only changes
-- [ ] Tested against real device if HID protocol was touched
-
----
-
-## 🚨 Hook Failures Are BLOCKING
-
-When any check fails, you MUST:
-1. **Stop immediately** — do not continue with other work
-2. **Fix all issues** — every ❌ until everything is ✅ GREEN
-3. **Verify the fix** — re-run the failed command to confirm
-4. **Resume original task** — return to where you were
-
-There are no warnings, only requirements.
-
----
-
-## Problem-Solving Together
-
-When stuck or in doubt:
-
-- **Stop** — don't spiral into complex solutions
-- **Step back** — re-read the requirements
-- **Simplify** — the simple solution is usually correct
-- **Ask** — "I see two approaches: [A] vs [B]. Which do you prefer?"
-
-My guidance on better approaches is always welcome — please ask for it.
-
-When protocol behaviour is uncertain, always say:
-> "I'm not sure about this byte offset / command value. We should verify with usbmon before assuming."
-
----
-
-## Communication Protocol
-
-Progress updates:
-```
-✓ Added FEAT_AUTO_GAIN constant and apply_response() branch, roundtrip test passes
-✓ EQ tab focus navigation complete, demo mode verified
-✗ GET feature address for monitor_mix looks wrong on firmware 1.2 — investigating
-```
-
-Suggesting improvements:
-> "The current approach works, but I notice [observation]. Would you like me to [specific improvement]?"
-
----
-
-## Security
-
-- The device HID interface is local hardware — no network exposure
-- Validate all packet arguments before encoding (clamp ranges, not panic)
-- No secrets in source — if a config file is added, use environment variables or `~/.config/`
-- Never write firmware update packets — the firmware update byte sequences are intentionally
-  omitted from this codebase (see readme legal section)
-
----
-
-## Working Memory
-
-When the conversation gets long:
-- Re-read this file
-- Summarize progress in `PROGRESS.md`
-- Keep `TODO.md` current:
-
-```markdown
-## Current Task
-- [ ] What we're doing RIGHT NOW
-
-## Completed
-- [x] What's done and tested
-
-## Next Steps
-- [ ] What comes next
-```
-
----
-
-> **Reminder**: If this file hasn't been referenced in 30+ minutes, re-read it.
-> This is always a feature branch — no backwards compatibility needed.
-> Clarity over cleverness, always.
-> When in doubt about protocol bytes, capture first — don't guess.
+Performance is not a concern (~100 ms input-driven tick rate) — no benchmarks unless a
+specific bottleneck is identified.


### PR DESCRIPTION
Cut the file from ~330 to ~150 lines with no loss of domain knowledge:

- Remove prompt-theater boilerplate: duplicate "mandatory checks" sections, scripted phrases, communication protocol, working memory (PROGRESS.md/TODO.md) rituals, and the re-read footer
- Merge FORBIDDEN/Required Standards/Security into a single Rust Rules list; fold layering invariants into Architecture
- Drop crate version pins (defer to Cargo.toml), keep only usage quirks that can't be inferred
- Preserve all protocol details: packet layout, CRC-16/ANSI spec, SET+CONFIRM, usbmon workflow, add-a-command sequence, meter/preset architecture, and testing table