### PR TITLE
v2.5.1 - update Cargo.toml for homebrew support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,10 @@ abstractions.
 Before considering any change complete:
 
 ```
-cargo clippy -- -D warnings && cargo fmt --check && cargo test
+cargo clippy --features probe -- -D warnings && cargo fmt --check && cargo test
 ```
+
+`--features probe` is required — `shurectl-probe` is feature-gated and clippy skips it otherwise.
 
 For non-trivial features, explore the relevant code and confirm a plan before implementing.
 
@@ -26,6 +28,7 @@ src/
   presets.rs    # Host-side presets: TOML load/save/delete, PresetSlot
   protocol.rs   # Packet encoding, CRC-16/ANSI, command constructors, apply_response()
   ui.rs         # ratatui rendering: 5 tabs (Main | EQ | Dynamics | Presets | Info) + help overlay
+  bin/probe.rs  # Maintainer-only HID address sweeper — builds only under `--features probe`
 ```
 
 **Control flow:** key event → `handle_key()` → `DeviceAction` → `apply_action()` (main.rs) → `device.rs` → `protocol.rs` packet.
@@ -35,6 +38,7 @@ src/
 **Layering rules (strict):**
 - `apply_action()` in `main.rs` is the *only* place that writes to the device. Never call `device.rs` from `ui.rs` or `app.rs`.
 - Raw protocol byte values live *only* in `protocol.rs` as named constants. Never hardcode bytes elsewhere.
+- `src/bin/probe.rs` builds as `shurectl-probe` only under `--features probe`. It is a maintainer tool and must never ship to end users via `cargo install` or Homebrew.
 
 ## USB HID Protocol
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,36 +21,13 @@ cargo build
 All of the following must pass clean before any commit:
 
 ```bash
-cargo clippy -- -D warnings && cargo fmt --check && cargo test
+cargo clippy --features probe -- -D warnings && cargo fmt --check && cargo test
 ```
 
+The `--features probe` flag is required: `shurectl-probe` is feature-gated and would
+otherwise be skipped by clippy entirely.
+
 There are no warnings — only requirements.
-
----
-
-## Using AI Assistants
-
-> **If you use an AI coding assistant (Claude, Copilot, Cursor, etc.), load `CLAUDE.md` into
-> its context before starting any work.**
-
-`CLAUDE.md` at the repository root is the authoritative source for this project's architecture,
-protocol rules, domain constraints, and coding standards. It covers the USB HID packet
-structure, the data flow between modules, forbidden patterns, and the required workflow for
-adding new commands. An AI working without it will produce code that conflicts with
-established patterns and is likely to introduce protocol bugs.
-
-Most AI tools support a project instructions file natively:
-
-- **Claude Projects** — add `CLAUDE.md` as project knowledge, or paste it into the system
-  prompt
-- **Cursor / Windsurf** — rename or symlink to `.cursorrules` / `.windsurfrules`, or
-  reference it in your rules file
-- **GitHub Copilot** — add it to `.github/copilot-instructions.md`
-- **Any chat-based tool** — paste the contents at the start of your session
-
-The key rules AI assistants must follow are called out explicitly in `CLAUDE.md`:
-the Research → Plan → Implement sequence, the one-change-at-a-time discipline when touching
-protocol code, and the requirement to run the quality gate before considering any work done.
 
 ---
 
@@ -77,15 +54,19 @@ All USB HID command byte values, feature addresses, and packet structure details
 
 The probe is **read-only** — it only sends GET packets, never SET or CONFIRM. It is safe to run against a live device; no settings will be changed.
 
+The probe binary is named `shurectl-probe` and is gated behind the `probe` cargo feature, so
+it is **not built by default**. This keeps it out of `cargo install` and Homebrew installs —
+end users have no reason to have an HID address sweeper in their `PATH`.
+
 ```bash
-cargo run --bin probe                                      # scan MVX2U Gen 2 (default)
-cargo run --bin probe -- --pid 0x1013                      # MVX2U Gen 1
-cargo run --bin probe -- --pid 0x1026                      # MV6
-cargo run --bin probe -- --also-mix-class                  # also sweep mix-class prefix
-cargo run --bin probe -- --also-lock-class                 # also sweep lock-class
-cargo run --bin probe -- --page 0x03                       # sweep a specific page only
-cargo run --bin probe -- --output results.txt              # write results to file
-cargo run --bin probe -- --delay-ms 50                     # increase if device misses responses
+cargo run --bin shurectl-probe --features probe                          # scan MVX2U Gen 2 (default)
+cargo run --bin shurectl-probe --features probe -- --pid 0x1013          # MVX2U Gen 1
+cargo run --bin shurectl-probe --features probe -- --pid 0x1026          # MV6
+cargo run --bin shurectl-probe --features probe -- --also-mix-class      # also sweep mix-class prefix
+cargo run --bin shurectl-probe --features probe -- --also-lock-class     # also sweep lock-class
+cargo run --bin shurectl-probe --features probe -- --page 0x03           # sweep a specific page only
+cargo run --bin shurectl-probe --features probe -- --output results.txt  # write results to file
+cargo run --bin shurectl-probe --features probe -- --delay-ms 50         # increase if device misses responses
 ```
 
 See the module-level doc comment in `src/bin/probe.rs` for full details on packet classes and known limitations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "shurectl"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "shurectl"
 version = "2.5.0"
 edition = "2024"
 description = "shurectl — TUI configurator for Shure USB audio interfaces and microphones"
+license = "GPL-3.0-only"
+repository = "https://github.com/Humblemonk/shurectl"
+keywords = ["shure", "motiv", "microphone", "usb-hid", "audio-interface"]
+categories = ["command-line-utilities", "hardware-support", "multimedia::audio"]
 
 [[bin]]
 name = "shurectl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shurectl"
-version = "2.5.0"
+version = "2.5.1"
 edition = "2024"
 description = "shurectl — TUI configurator for Shure USB audio interfaces and microphones"
 license = "GPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,14 @@ categories = ["command-line-utilities", "hardware-support", "multimedia::audio"]
 name = "shurectl"
 path = "src/main.rs"
 
+[[bin]]
+name = "shurectl-probe"
+path = "src/bin/probe.rs"
+required-features = ["probe"]
+
+[features]
+probe = []
+
 [dependencies]
 ratatui = "0.30"
 crossterm = "0.29"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ Or for your user only:
 install -m 755 target/release/shurectl ~/.local/bin/
 ```
 
+### Via Homebrew (macOS)
+
+```bash
+brew install humblemonk/shurectl/shurectl
+```
+
+Updates arrive through `brew upgrade` like any other formula. The formula builds from
+source, so the first install pulls in a Rust toolchain and takes a minute or two.
+
 ### Via cargo install
 
 ```bash


### PR DESCRIPTION
feat: gate probe binary behind `probe` feature as shurectl-probe

Cargo auto-discovers src/bin/*.rs regardless of an explicit [[bin]] for
main.rs, so `cargo install` and Homebrew would both drop a bare `probe`
binary into the user's PATH. An undocumented HID address sweeper has no
business being there.

Rename to shurectl-probe and require --features probe, keeping it out of
default builds while remaining available for reconnaissance work. Update
the quality gate to pass --features probe so clippy still covers it.

also update documents to call out homebrew option