### PR TITLE
docs: add cross-device UI consistency rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # shurectl
 
-Terminal UI configurator for Shure USB audio interfaces (MVX2U, MV6) on Linux and macOS.
+Terminal UI configurator for Shure USB audio interfaces (MVX2U Gen 1/Gen 2, MV6, MV7+) on
+Linux and macOS.
 Replaces the Windows/Mac-only ShurePlus MOTIV Desktop app by talking to the device directly
 over USB HID. Single-crate Rust binary. Prefer the simple, obvious solution over clever
 abstractions.
@@ -51,7 +52,7 @@ Every packet is exactly 64 bytes (65 with hidapi's report-ID byte 0), sent via `
   ^report ID    ^magic, never changes            CRC-16/ANSI covers 0x11 onward
 ```
 
-- **USB IDs:** VID `0x14ED`, PID `0x1013`
+- **USB IDs:** VID `0x14ED`; PID `0x1013` (MVX2U Gen 1), `0x1033` (MVX2U Gen 2), `0x1026` (MV6), `0x1019` (MV7+)
 - **CRC:** CRC-16/ANSI — poly `0x8005`, init `0x0000`, reflected in/out (NOT CCITT-FALSE)
 - **SET + CONFIRM:** every SET must be immediately followed by a `CMD_CONFIRM` packet or the device won't apply the change
 - **State readback:** no monolithic GET_STATE. `device.rs::get_state()` issues individual `cmd_get_*` packets; `apply_response()` dispatches on the 2-byte feature address and writes into `DeviceState`. Feature address → field mapping is documented inline in `protocol.rs`.
@@ -77,9 +78,11 @@ Follow this sequence, no skipped steps:
 2. `device.rs` — typed `get_*`/`set_*` methods on `Mvx2u`; add getter to the `getters` slice in `get_state()` if part of full readback
 3. `app.rs` — `DeviceAction` variant if user-triggerable; wire into `adjust_focused()` or `toggle_focused()`
 4. `main.rs` — handle the variant in `apply_action()`
-5. `ui.rs` — UI element if needed
+5. `ui.rs` — UI element if needed; check **Cross-Device UI Consistency** below before
+   inventing a new label, keybinding, or per-model draw function
 6. `protocol.rs` — roundtrip test for the new packet
-7. `README.md` — update protocol table and keyboard shortcuts
+7. `README.md` — update protocol table and keyboard shortcuts, noting model applicability if
+   the command is not universal
 
 ## TUI / Focus Model
 
@@ -87,6 +90,64 @@ Follow this sequence, no skipped steps:
 - `adjust_focused()` handles ←/→ for sliders; `toggle_focused()` handles Enter/Space for booleans and enum cycling
 - Both return `Option<DeviceAction>` — `None` means UI-only change, no HID write
 - Preset name editing lives in `main.rs::handle_key()` (not `toggle_focused()`): when `editing_preset_name` is true, chars append, Enter commits (`PersistPresetName`), Esc cancels
+
+## Cross-Device UI Consistency
+
+**Every supported model must feel like the same program.** A user owns one device but reads
+one README, one help overlay, and one set of screenshots. If "Gain Lock" on the Gen 2 is
+"Lock" on the MV6, or Tab order differs, or ←/→ adjusts on one model and Enter cycles on
+another, the docs stop matching reality for most users. It is also the single largest
+maintenance cost in this codebase: `ui.rs` already carries eight `draw_main_left_*` variants
+and four-way `DeviceModel` matches in `draw_main_right()`, `draw_info_tab()`,
+`default_focus()`, `next_focus()`, and `prev_focus()`. Every divergence multiplies across
+all of them.
+
+**The rule:** any control that exists on more than one model must have identical label,
+units, value formatting, keybinding, and position relative to its neighbours on all of them.
+Only genuinely device-exclusive hardware features may differ.
+
+Shared across all models unless the hardware makes it impossible:
+
+- **Tab set and order** — `Tab::ALL` is the source of truth; models filter it, never reorder it
+- **Keybindings** — Tab/Shift-Tab cycles tabs, ↑/↓ moves focus, ←/→ adjusts, Enter/Space toggles, `?` help. No model-specific keys
+- **Focus traversal shape** — same logical order (mode → mute → gain → monitor mix → device extras). Models skip entries they lack; they do not reshuffle
+- **Labels, units, and formatting** — "Gain", "Monitor Mix", "Denoiser" mean the same thing everywhere and are spelled the same way. dB values, percentages, and enum names render through the same code path
+- **Drawing helpers** — `draw_mode_block()`, `draw_mute_block()`, `draw_monitor_mix_gauge()`, `draw_gain_lock_block()`, `draw_phantom_block()`, `segmented_span()`, `draw_main_shared()`. Extend a helper with a parameter rather than forking a near-copy
+- **Status and error wording** — same phrasing for the same condition regardless of model
+
+**Hiding vs. locking** — the convention established in `draw_tabs()`, apply it to controls too:
+
+- Permanently unsupported on this hardware → hide entirely (Reverb/LED on non-MV7+)
+- Supported but currently unavailable → show with 🔒 and a notice (EQ/Dynamics on Gen 1 in
+  Auto mode, via `draw_tab_locked_notice()`)
+
+Never leave a control visible and focusable but inert — that reads as a bug.
+
+**Before adding anything model-specific, in order:**
+
+1. Do other models have the same capability under a different vendor name? If so, adopt the
+   existing shurectl name and control, not the vendor's. Vendor naming inconsistency stops
+   at `protocol.rs`.
+2. Can an existing shared helper render it? Prefer extending the helper.
+3. If a per-model `draw_*` fork is genuinely required, keep block order, borders, and
+   spacing identical to its siblings so the screens are visually interchangeable.
+4. Update *every* exhaustive `DeviceModel` match — focus fns, both `draw_main_*`,
+   `draw_info_tab()`, and preset serialization. A missing arm is a silent UX divergence, not
+   a compile error, wherever `_` was used.
+5. Verify with `--demo mvx2u`, `--demo mvx2u-gen2`, `--demo mv6`, and `--demo mv7plus`, not
+   just the model on your desk.
+
+**Anti-patterns:**
+
+- Copying `draw_main_left_gen2_manual()` to bootstrap a new model, then tweaking strings —
+  this is how label drift starts
+- Adding a keybinding that only one model responds to
+- Reordering tabs or focus for one model because it "reads better" there
+- Hardcoding a model name in a shared helper instead of passing behaviour in
+- Documenting a shortcut in `README.md` that only applies to some devices without saying so
+
+When a genuine divergence is unavoidable, say so explicitly in the PR/commit body and note
+which models are affected — silent divergence is the failure mode.
 
 ## Meter
 


### PR DESCRIPTION
Codify the requirement that shared controls behave identically across all supported models. ui.rs already carries eight draw_main_left_* variants and four-way DeviceModel matches in draw_main_right(), draw_info_tab(), and the focus functions — every divergence multiplies across all of them and breaks the single README/help overlay users read.

- New "Cross-Device UI Consistency" section after the TUI/Focus Model section: shared tab order, keybindings, focus traversal shape, labels, units, and drawing helpers; hide-vs-lock convention from draw_tabs() generalized to controls; pre-flight checklist and anti-patterns
- "Adding a New Command" steps 5 and 7 now reference it, and ask for model applicability in README updates

Also correct stale facts: intro listed only MVX2U and MV6 (now includes Gen 2 and MV7+), and USB IDs listed only PID 0x1013 (now all four PIDs).