### PR TITLE
fix: drop unused test imports, document verification gap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,22 @@ abstractions.
 Before considering any change complete:
 
 ```
-cargo clippy --features probe -- -D warnings && cargo fmt --check && cargo test
+cargo clippy --features probe -- -D warnings && cargo build --all-targets --features probe \
+  && cargo fmt --check && cargo test
 ```
 
 `--features probe` is required — `shurectl-probe` is feature-gated and clippy skips it otherwise.
+
+`cargo build --all-targets` is required for a different reason: clippy without `--all-targets`
+never compiles `#[cfg(test)]` code, so a dead import or unused helper left behind in a test
+module passes the clippy gate and only surfaces later in someone else's build log. Read the
+`cargo test` output rather than grepping it for `test result` — that is where such warnings
+appear.
+
+Adding `--all-targets` to the clippy line as well would be better still, but it currently
+fails on ~39 pre-existing `clippy::field_reassign_with_default` warnings in the `app.rs`
+tests (the `let mut app = App::default(); app.active_tab = …;` pattern). Fold those into
+struct literals first, then tighten the gate.
 
 CI also runs a duplicate-code detector (jscpd, via super-linter). Its budget lives in
 `.github/linters/.jscpd.json` and is currently 7% duplicated lines against ~5.5% actual, so

--- a/src/app.rs
+++ b/src/app.rs
@@ -1976,6 +1976,98 @@ mod tests {
         assert_eq!(app.focus, Focus::Denoiser); // wrap
     }
 
+    /// Gen 2 Manual shows all five controls. The order must match the card order
+    /// in `draw_gen2_dynamics_tab()`.
+    #[test]
+    fn gen2_dynamics_tab_manual_focus_cycles_all_five_controls() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mvx2uGen2;
+        app.active_tab = Tab::Dynamics;
+        app.device_state.mode = InputMode::Manual;
+        app.focus = Focus::Limiter;
+
+        // Forward: Limiter → Compressor → Denoiser → PopperStopper → Hpf → wrap
+        for expected in [
+            Focus::Compressor,
+            Focus::Denoiser,
+            Focus::PopperStopper,
+            Focus::Hpf,
+            Focus::Limiter,
+        ] {
+            app.focus_next();
+            assert_eq!(app.focus, expected, "focus_next: expected {expected:?}");
+        }
+
+        // Backward over the same cycle
+        for expected in [
+            Focus::Hpf,
+            Focus::PopperStopper,
+            Focus::Denoiser,
+            Focus::Compressor,
+            Focus::Limiter,
+        ] {
+            app.focus_prev();
+            assert_eq!(app.focus, expected, "focus_prev: expected {expected:?}");
+        }
+    }
+
+    /// Gen 2 Auto hides Limiter and Compressor, so focus must skip them entirely
+    /// rather than land on a control the tab does not draw.
+    #[test]
+    fn gen2_dynamics_tab_auto_focus_skips_limiter_and_compressor() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mvx2uGen2;
+        app.active_tab = Tab::Dynamics;
+        app.device_state.mode = InputMode::Auto;
+        app.focus = Focus::Denoiser;
+
+        for expected in [Focus::PopperStopper, Focus::Hpf, Focus::Denoiser] {
+            app.focus_next();
+            assert_eq!(app.focus, expected, "focus_next: expected {expected:?}");
+            assert_ne!(app.focus, Focus::Limiter);
+            assert_ne!(app.focus, Focus::Compressor);
+        }
+
+        for expected in [Focus::Hpf, Focus::PopperStopper, Focus::Denoiser] {
+            app.focus_prev();
+            assert_eq!(app.focus, expected, "focus_prev: expected {expected:?}");
+        }
+    }
+
+    /// MV7+ shows all six controls. The order must match the card order in
+    /// `draw_mv7plus_dynamics_tab()`.
+    #[test]
+    fn mv7plus_dynamics_tab_focus_cycles_all_six_controls() {
+        let mut app = App::default();
+        app.device_model = DeviceModel::Mv7Plus;
+        app.active_tab = Tab::Dynamics;
+        app.focus = Focus::Limiter;
+
+        for expected in [
+            Focus::Compressor,
+            Focus::Denoiser,
+            Focus::PopperStopper,
+            Focus::MuteBtnDisable,
+            Focus::Hpf,
+            Focus::Limiter,
+        ] {
+            app.focus_next();
+            assert_eq!(app.focus, expected, "focus_next: expected {expected:?}");
+        }
+
+        for expected in [
+            Focus::Hpf,
+            Focus::MuteBtnDisable,
+            Focus::PopperStopper,
+            Focus::Denoiser,
+            Focus::Compressor,
+            Focus::Limiter,
+        ] {
+            app.focus_prev();
+            assert_eq!(app.focus, expected, "focus_prev: expected {expected:?}");
+        }
+    }
+
     // ── preset focus / toggle ─────────────────────────────────────────────────
 
     #[test]

--- a/src/presets.rs
+++ b/src/presets.rs
@@ -812,9 +812,6 @@ impl From<SerLedPulsingTheme> for LedPulsingTheme {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{
-        LedBehavior, LedBrightness, LedLiveTheme, LedPulsingTheme, LedSolidTheme,
-    };
 
     /// A fully populated state whose every field differs from `DeviceState::default()`
     /// where the roundtrip tests care, so a dropped field shows up as a mismatch.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -2455,6 +2455,103 @@ mod tests {
 
     // ── parse_response ────────────────────────────────────────────────────────
 
+    // ── Golden packets ────────────────────────────────────────────────────────
+    //
+    // Full literal byte sequences for four representative packets. Every other
+    // encoding test asserts individual offsets, and `make_response` builds its
+    // fixtures with `build_packet` — so without these, a change to the framing
+    // would move the builder and the parser together and no test would notice.
+    // The CRC in each was verified against an independent implementation of
+    // CRC-16/ANSI (poly 0x8005 reflected, init 0x0000) rather than copied from
+    // this module's own output.
+    //
+    // If one of these fails, the wire format changed. Confirm against a usbmon
+    // capture before updating the literal — do not just paste in the new bytes.
+
+    /// Standard framing, HDR_CONSTANT=0x03: SET gain to 30 dB, seq 0x05.
+    #[test]
+    fn golden_packet_set_gain() {
+        let pkt = cmd_set_gain(0x05, 30);
+        assert_eq!(
+            &pkt[..20],
+            &[
+                0x01, // report ID
+                0x12, // total_len
+                0x11, 0x22, // header magic
+                0x05, // seq
+                0x03, // HDR_CONSTANT
+                0x08, // HDR_END
+                0x0A, // data_len
+                0x70, // DATA_START
+                0x0A, // data_len (repeated)
+                0x02, 0x02, 0x02, // CMD_SET_FEAT
+                0x00, // is_mix
+                0x01, 0x02, // FEAT_GAIN
+                0x0B, 0xB8, // 3000 = 30 dB in hundredths
+                0x8A, 0xD6, // CRC-16/ANSI
+            ]
+        );
+        assert_eq!(pkt.len(), PACKET_SIZE);
+        assert!(
+            pkt[20..].iter().all(|&b| b == 0x00),
+            "tail must be zero padded"
+        );
+    }
+
+    /// Standard framing with a single-byte value: SET phantom power on, seq 0x05.
+    #[test]
+    fn golden_packet_set_phantom() {
+        let pkt = cmd_set_phantom(0x05, true);
+        assert_eq!(
+            &pkt[..19],
+            &[
+                0x01, 0x11, 0x11, 0x22, 0x05, 0x03, 0x08, 0x09, 0x70, 0x09, //
+                0x02, 0x02, 0x02, // CMD_SET_FEAT
+                0x00, // is_mix
+                0x01, 0x66, // FEAT_PHANTOM
+                0x30, // PHANTOM_ON (48 = 48V)
+                0x5E, 0x85, // CRC-16/ANSI
+            ]
+        );
+        assert_eq!(pkt.len(), PACKET_SIZE);
+    }
+
+    /// The other framing variant, HDR_CONSTANT=0x00: MV6 monitor mix at 50, seq 0x05.
+    /// Byte 5 is the only difference from the standard framing above.
+    #[test]
+    fn golden_packet_mv6_mix_uses_hdr_constant_zero() {
+        let pkt = cmd_set_mv6_mix(0x05, 50);
+        assert_eq!(
+            &pkt[..19],
+            &[
+                0x01, 0x11, 0x11, 0x22, 0x05, //
+                0x00, // HDR_CONSTANT=0x00, not 0x03
+                0x08, 0x09, 0x70, 0x09, //
+                0x02, 0x02, 0x02, // CMD_SET_FEAT
+                0x00, // is_mix
+                0x01, 0x86, // FEAT_MIX
+                0x32, // mix = 50
+                0x5B, 0x49, // CRC-16/ANSI
+            ]
+        );
+        assert_eq!(pkt.len(), PACKET_SIZE);
+    }
+
+    /// The CONFIRM packet that must follow every SET, seq 0x05.
+    #[test]
+    fn golden_packet_confirm() {
+        let pkt = cmd_confirm(0x05);
+        assert_eq!(
+            &pkt[..15],
+            &[
+                0x01, 0x0D, 0x11, 0x22, 0x05, 0x03, 0x08, 0x05, 0x70, 0x05, //
+                0x01, 0x00, 0x00, // CMD_CONFIRM
+                0x8B, 0x16, // CRC-16/ANSI
+            ]
+        );
+        assert_eq!(pkt.len(), PACKET_SIZE);
+    }
+
     /// Build a synthetic response from the device for testing parse_response.
     fn make_response(seq: u8, resp_cmd: &[u8; 3], feat_addr: &[u8; 2], value: &[u8]) -> Vec<u8> {
         let is_mix: u8 = 0x00;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3251,6 +3251,61 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
 mod tests {
     use super::*;
 
+    // ── enum_options ──────────────────────────────────────────────────────────
+    //
+    // Single source of truth for the ▶ marker on every Enter-cycled control
+    // (HPF, Compressor, Reverb Type) across all four models, so a bug here is a
+    // bug on every Dynamics and Reverb tab at once.
+
+    #[test]
+    fn enum_options_marks_exactly_the_current_variant() {
+        let opts = enum_options(
+            &[HpfFrequency::Off, HpfFrequency::Hz75, HpfFrequency::Hz150],
+            HpfFrequency::Hz75,
+        );
+        assert_eq!(opts.len(), 3);
+        assert_eq!(opts.iter().filter(|(_, selected)| *selected).count(), 1);
+        assert!(opts[1].1, "Hz75 is the current value");
+        assert!(!opts[0].1);
+        assert!(!opts[2].1);
+    }
+
+    #[test]
+    fn enum_options_preserves_declaration_order_and_labels() {
+        let opts = enum_options(
+            &[
+                CompressorPreset::Off,
+                CompressorPreset::Light,
+                CompressorPreset::Medium,
+                CompressorPreset::Heavy,
+            ],
+            CompressorPreset::Heavy,
+        );
+        let labels: Vec<&str> = opts.iter().map(|(l, _)| l.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec![
+                CompressorPreset::Off.to_string(),
+                CompressorPreset::Light.to_string(),
+                CompressorPreset::Medium.to_string(),
+                CompressorPreset::Heavy.to_string(),
+            ]
+        );
+        assert!(opts[3].1, "last variant is the current value");
+    }
+
+    #[test]
+    fn enum_options_marks_nothing_when_current_is_absent() {
+        // Guards the Gen 1 Auto case, where a control can hold a value the
+        // rendered list does not offer: no row should be marked rather than
+        // defaulting the marker onto the first one.
+        let opts = enum_options(
+            &[HpfFrequency::Hz75, HpfFrequency::Hz150],
+            HpfFrequency::Off,
+        );
+        assert!(opts.iter().all(|(_, selected)| !*selected));
+    }
+
     // ── meter_color ───────────────────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
The preset fixture rewrite left five LED enum imports orphaned in presets.rs tests. Clippy without --all-targets never compiles test code, so add cargo build --all-targets to the verification command in CLAUDE.md.